### PR TITLE
fix(ci): use node 22 for semantic-release

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          # semantic-release@25 requires Node >= 22.14.0
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install Dependencies


### PR DESCRIPTION
## Fix
- Run semantic-release with Node 22.x (semantic-release@25 requires >=22.14.0).

## Why
The release workflow currently uses Node 20.x and fails with:
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required.
