### PR TITLE
fix(ci): run semantic-release on node 22

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # semantic-release@25 requires Node >= 22.14.0
-          node-version: '22.x'
+          node-version: '20.x'
           cache: 'npm'
 
       - name: Install Dependencies
@@ -69,7 +68,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          # semantic-release@25 requires Node >= 22.14.0
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Fix
- Run the **Semantic Release** job with Node 22.x (semantic-release@25 requires >=22.14.0).
- Keep the test job on Node 20.x.

## Why
The workflow on main still runs semantic-release under Node 20.x and fails with:
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.x.
