### PR TITLE
fix(e2e): stabilize mounts empty state

### DIFF
--- a/src/views/MountsView.tsx
+++ b/src/views/MountsView.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { MountPoint, Repository, Archive } from '../types';
 import Button from '../components/Button';
 import { FolderOpen, XCircle, HardDrive, Terminal, Loader2, Info, Plus, ChevronUp, ChevronDown, CheckCircle2 } from 'lucide-react';
@@ -18,6 +18,7 @@ const MountsView: React.FC<MountsViewProps> = ({ mounts, repos, archives, onUnmo
   const [selectedRepo, setSelectedRepo] = useState(repos[0]?.id || '');
   const [selectedArchive, setSelectedArchive] = useState(archives[0]?.name || '');
   const [commandPreview, setCommandPreview] = useState('');
+  const lastAppliedPreselectedRepoId = useRef<string | null>(null);
   
   const [useWsl, setUseWsl] = useState(true);
   
@@ -25,11 +26,14 @@ const MountsView: React.FC<MountsViewProps> = ({ mounts, repos, archives, onUnmo
      const storedWsl = localStorage.getItem('winborg_use_wsl');
      setUseWsl(storedWsl === null ? true : storedWsl === 'true');
 
-     if (preselectedRepoId) {
+      if (preselectedRepoId && preselectedRepoId !== lastAppliedPreselectedRepoId.current) {
         setIsCreating(true);
         setSelectedRepo(preselectedRepoId);
+        lastAppliedPreselectedRepoId.current = preselectedRepoId;
      } else if (!selectedRepo && repos.length > 0) {
         setSelectedRepo(repos[0].id);
+      } else if (!preselectedRepoId && lastAppliedPreselectedRepoId.current) {
+        lastAppliedPreselectedRepoId.current = null;
      }
 
      if (!selectedArchive && archives.length > 0) {


### PR DESCRIPTION
Fixes a flaky/incorrect Mounts empty-state behavior that caused the Playwright E2E test 'mount archive then unmount' to fail.

Root cause:
- MountsView was re-applying preselectedRepoId on every render, forcing isCreating=true even after Unmount.
- When mounts became empty, the empty-state ('No active mounts') was hidden due to !isCreating guard.

Change:
- Track the last applied preselectedRepoId and only auto-open mount creation once per selection.

Validation:
- 
pm run test:e2e passes locally.