### PR TITLE
fix(release): don't push to protected main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -32,13 +32,6 @@
           }
         ]
       }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
Fixes Semantic Release failure on protected main.

Root cause:
- .releaserc.json used @semantic-release/git, which commits and pushes back to main (updates package.json).
- Branch protection blocks direct pushes, so the release job fails with GH006.

Change:
- Remove @semantic-release/git from .releaserc.json so releases only create tags/releases and upload artifacts.

Notes:
- Version is still written during the CI build via @semantic-release/npm, but it is no longer committed back to the repo.