### PR TITLE
fix(ui): use app.getVersion for displayed version

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -315,6 +315,15 @@ function getDecryptedPassword(id) {
 
 const isDev = !app.isPackaged && process.env.NODE_ENV !== 'test';
 
+// Expose app version to renderer (prefer this over build-time env vars).
+ipcMain.handle('get-app-version', async () => {
+    try {
+        return (typeof app.getVersion === 'function') ? app.getVersion() : null;
+    } catch (e) {
+        return null;
+    }
+});
+
 function escapePythonSingleQuotedString(value) {
     return String(value ?? '')
         .replace(/\\/g, "\\\\")

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -64,13 +64,19 @@ describe('Sidebar', () => {
     });
 
     it('handles GitHub link click (Fallback mode)', () => {
-        // Suppress mockRequire to force fallback
-        mockRequire.mockImplementationOnce(() => { throw new Error('Not found') });
+        // Suppress mockRequire to force fallback (Sidebar also queries app version on mount)
+        const prevImpl = mockRequire.getMockImplementation();
+        mockRequire.mockImplementation(() => {
+            throw new Error('Not found');
+        });
         
         render(<Sidebar currentView={View.DASHBOARD} onChangeView={vi.fn()} />);
         const devArea = screen.getByTitle('View on GitHub');
         
         fireEvent.click(devArea);
         expect(window.open).toHaveBeenCalled();
+
+        // Restore for other tests
+        mockRequire.mockImplementation(prevImpl as any);
     });
 });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { HardDrive, Server, Settings, LayoutDashboard, Database, Activity, Github, Code2, Heart, ArrowUpCircle } from 'lucide-react';
 import { View } from '../types';
 import AppLogo from './AppLogo';
+import { getAppVersion } from '../utils/appVersion';
 
 interface SidebarProps {
   currentView: View;
@@ -10,6 +11,18 @@ interface SidebarProps {
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ currentView, onChangeView, updateAvailable }) => {
+  const [appVersion, setAppVersion] = useState<string | null>((process.env as any)?.APP_VERSION ?? null);
+
+  useEffect(() => {
+    let isMounted = true;
+    getAppVersion().then((v) => {
+      if (isMounted) setAppVersion(v);
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   const navItems = [
     { view: View.DASHBOARD, label: 'Dashboard', icon: LayoutDashboard },
     { view: View.REPOSITORIES, label: 'Repositories', icon: Server },
@@ -23,7 +36,7 @@ const Sidebar: React.FC<SidebarProps> = ({ currentView, onChangeView, updateAvai
       name: "robotnikz",
       role: "Developer",
       repo: "robotnikz/WinBorg",
-      version: "v" + process.env.APP_VERSION
+      version: "v" + (appVersion || '0.0.0')
   };
 
   const handleOpenRepo = (e: React.MouseEvent) => {

--- a/src/components/SystemStatusModal.tsx
+++ b/src/components/SystemStatusModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { X, CheckCircle2, AlertTriangle, Terminal, HardDrive, Wifi, Server } from 'lucide-react';
+import { getAppVersion } from '../utils/appVersion';
 
 interface SystemStatusModalProps {
   isOpen: boolean;
@@ -31,9 +32,10 @@ const SystemStatusModal: React.FC<SystemStatusModalProps> = ({ isOpen, onClose }
       const { ipcRenderer } = (window as any).require('electron');
       
       // Parallel system checks
-      const [wslResult, borgResult] = await Promise.all([
+      const [wslResult, borgResult, appVersion] = await Promise.all([
         ipcRenderer.invoke('system-check-wsl'),
         ipcRenderer.invoke('system-check-borg'),
+        getAppVersion(),
       ]);
 
       setStatus({
@@ -42,7 +44,7 @@ const SystemStatusModal: React.FC<SystemStatusModalProps> = ({ isOpen, onClose }
         borgVersion: borgResult.installed ? (borgResult.version || 'Detected') : 'Not Found',
         borgPath: borgResult.path || 'Unknown',
         networkStatus: navigator.onLine ? 'connected' : 'offline',
-        backendVersion: 'v' + process.env.APP_VERSION || 'Unknown'
+        backendVersion: appVersion ? `v${appVersion}` : 'Unknown'
       });
     } catch (e) {
       console.error("Status Check Failed", e);

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -1,0 +1,34 @@
+type IpcRendererLike = {
+  invoke?: (channel: string, payload?: any) => Promise<any>;
+};
+
+function getIpcRenderer(): IpcRendererLike | null {
+  try {
+    const req = (window as any)?.require;
+    if (typeof req !== 'function') return null;
+    const electron = req('electron');
+    return electron?.ipcRenderer ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the app version as a plain semver string, preferring the main-process
+ * value (app.getVersion()) to avoid relying on repo/package.json state.
+ */
+export async function getAppVersion(): Promise<string | null> {
+  const ipcRenderer = getIpcRenderer();
+
+  if (ipcRenderer?.invoke) {
+    try {
+      const value = await ipcRenderer.invoke('get-app-version');
+      if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+    } catch {
+      // fall back
+    }
+  }
+
+  const fallback = (process.env as any)?.APP_VERSION;
+  return (typeof fallback === 'string' && fallback.trim().length > 0) ? fallback.trim() : null;
+}

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -7,6 +7,7 @@ import {
     Settings, Shield, Globe, Cpu, ChevronRight, Upload
 } from 'lucide-react';
 import { borgService } from '../services/borgService';
+import { getAppVersion } from '../utils/appVersion';
 
 // Helper component for Section Cards
 const SettingsCard: React.FC<{
@@ -35,6 +36,8 @@ type SettingsTab = 'general' | 'automation' | 'notifications' | 'system';
 
 const SettingsView: React.FC = () => {
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
+
+    const [appVersion, setAppVersion] = useState<string | null>((process.env as any)?.APP_VERSION ?? null);
 
   // Application Settings
   const [useWsl, setUseWsl] = useState(true);
@@ -128,6 +131,16 @@ const SettingsView: React.FC = () => {
         setUseWsl(storedWsl === null ? true : storedWsl === 'true');
     }
   }, []);
+
+    useEffect(() => {
+        let isMounted = true;
+        getAppVersion().then((v) => {
+            if (isMounted) setAppVersion(v);
+        });
+        return () => {
+            isMounted = false;
+        };
+    }, []);
 
   useEffect(() => {
       const ipc = getElectron()?.ipcRenderer;
@@ -388,7 +401,7 @@ const SettingsView: React.FC = () => {
                        <div className="flex items-center justify-between p-1">
                            <div>
                                <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Check for Updates</div>
-                               <p className="text-xs text-slate-500 dark:text-slate-400">Current version: {process.env.APP_VERSION || 'Web Dev'}</p>
+                               <p className="text-xs text-slate-500 dark:text-slate-400">Current version: {appVersion || (process.env as any).APP_VERSION || 'Web Dev'}</p>
                            </div>
                            <Button variant="secondary" onClick={handleCheckUpdate} className="dark:bg-slate-700 dark:text-slate-200 dark:border-slate-600">
                                Check Now


### PR DESCRIPTION
Use the main-process app version for UI displays to avoid relying on repo/package.json state.

Changes:
- Add IPC handler get-app-version (returns app.getVersion()).
- Add renderer helper to fetch version with fallback to process.env.APP_VERSION.
- Update Sidebar/SettingsView/SystemStatusModal to show the IPC-derived version.
- Fix SystemStatusModal precedence bug that could display vundefined.

Validation:
- npx vitest run