### PR TITLE
Show scheduled backup status/ETA on dashboard

### DIFF
--- a/src/services/borgService.ts
+++ b/src/services/borgService.ts
@@ -698,7 +698,7 @@ export const borgService = {
       archiveName: string, 
       sourcePaths: string[], 
       onLog: (text: string) => void,
-      overrides?: { repoId?: string, disableHostCheck?: boolean, remotePath?: string },
+      overrides?: { repoId?: string, disableHostCheck?: boolean, remotePath?: string, commandId?: string },
       options?: { excludePatterns?: string[] }
   ): Promise<boolean> => {
       const config = getBorgConfig();

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,13 @@ export interface Repository {
   
   // To allow aborting
   activeCommandId?: string;
+
+  // Backup Run State (One-off or Job)
+  backupStatus?: 'idle' | 'running' | 'success' | 'error' | 'aborted';
+  backupStartTime?: number; // Timestamp in ms
+  backupEstimatedDurationMs?: number; // Used for ETA/progress bar (heuristic)
+  activeBackupCommandId?: string; // For cancelling a running backup
+  activeBackupJobId?: string; // If the running backup was triggered by a job
 }
 
 export interface BackupJob {


### PR DESCRIPTION
## What''s in this PR

This makes **scheduled (background) backups** show up on the dashboard repo cards with the same **Status + ETA + Cancel** UX as one-off backups.

## User-visible changes
- Dashboard repo cards show a running backup bar (**status + ETA**) for **scheduled jobs**.
- Scheduled jobs can be **cancelled** via the existing stop pathway (same UX as one-off).

## Implementation details

### IPC payloads
Background scheduler events now include enough context for the renderer to update repo state:

| Event | Payload | Purpose |
| --- | --- | --- |
| `job-started` | `{ jobId, repoId, commandId }` | Mark job + repo backup as running |
| `job-complete` | `{ jobId, repoId, commandId, success }` | Clear repo backup state; mark job success/error |

> Backward compatibility: the renderer still supports the legacy `job-started` payload (jobId string).

### Cancellation
Scheduled borg processes are registered under a stable `commandId`, so `borg-stop` can cancel them from the renderer.

## Testing
- `npm test`

## Notes
- ETA uses the existing local duration history; the scheduled-job path now records durations as well (on success).
