### PR TITLE
feat(ui): add changelog to update notification modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1017,6 +1017,7 @@ const App: React.FC = () => {
                 }
             }}
             version={updateInfo?.version || ''}
+            releaseNotes={updateInfo?.releaseNotes}
             downloading={isDownloadingUpdate}
             progress={updateProgress}
             readyToInstall={isUpdateReady}

--- a/src/components/UpdateModal.test.tsx
+++ b/src/components/UpdateModal.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import UpdateModal from './UpdateModal';
+
+vi.mock('./Button', () => ({
+    default: ({ children, onClick }: any) => (
+        <button type="button" onClick={onClick}>
+            {children}
+        </button>
+    )
+}));
+
+describe('UpdateModal', () => {
+    it('hides changelog by default and toggles it', () => {
+        render(
+            <UpdateModal
+                isOpen={true}
+                onClose={() => {}}
+                onUpdate={() => {}}
+                version="1.2.3"
+                downloading={false}
+                readyToInstall={false}
+                releaseNotes={'- Added feature A\n- Fixed bug B'}
+            />
+        );
+
+        // Hidden by default
+        expect(screen.queryByText(/Added feature A/i)).not.toBeInTheDocument();
+
+        const toggle = screen.getByRole('button', { name: /Changelog/i });
+        fireEvent.click(toggle);
+
+        expect(screen.getByText(/Added feature A/i)).toBeInTheDocument();
+
+        fireEvent.click(toggle);
+        expect(screen.queryByText(/Added feature A/i)).not.toBeInTheDocument();
+    });
+
+    it('does not render changelog while downloading', () => {
+        render(
+            <UpdateModal
+                isOpen={true}
+                onClose={() => {}}
+                onUpdate={() => {}}
+                version="1.2.3"
+                downloading={true}
+                progress={10}
+                readyToInstall={false}
+                releaseNotes={'- Added feature A'}
+            />
+        );
+
+        expect(screen.queryByRole('button', { name: /Changelog/i })).not.toBeInTheDocument();
+    });
+});

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Download, X, AlertCircle } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Download, X, AlertCircle, ChevronDown, ChevronUp } from 'lucide-react';
 import Button from './Button';
 
 interface UpdateModalProps {
@@ -10,10 +10,62 @@ interface UpdateModalProps {
     downloading: boolean;
     progress?: number;
     readyToInstall?: boolean;
+    releaseNotes?: unknown;
 }
 
-const UpdateModal: React.FC<UpdateModalProps> = ({ isOpen, onClose, onUpdate, version, downloading, progress, readyToInstall }) => {
+function normalizeReleaseNotes(releaseNotes: unknown): string {
+    if (!releaseNotes) return '';
+
+    // electron-updater can provide either a string or an array of { version, note }
+    // where note can be a string or (rarely) an object.
+    if (typeof releaseNotes === 'string') return releaseNotes;
+    if (Array.isArray(releaseNotes)) {
+        const parts = releaseNotes
+            .map((x) => {
+                if (typeof x === 'string') return x;
+                if (x && typeof x === 'object') {
+                    const anyX = x as any;
+                    if (typeof anyX.note === 'string') return anyX.note;
+                    if (typeof anyX.notes === 'string') return anyX.notes;
+                }
+                return '';
+            })
+            .filter(Boolean);
+        return parts.join('\n\n');
+    }
+
+    try {
+        return JSON.stringify(releaseNotes, null, 2);
+    } catch {
+        return String(releaseNotes);
+    }
+}
+
+function toPlainText(input: string): string {
+    // Some release notes come as HTML. We render as plain text to avoid HTML injection.
+    // Use DOMParser/textContent instead of regex-based sanitization (avoids CodeQL issues).
+    if (!input) return '';
+    try {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(input, 'text/html');
+        const text = (doc.body && doc.body.textContent) ? doc.body.textContent : '';
+        return String(text).replace(/\r\n/g, '\n').trim();
+    } catch {
+        return String(input).replace(/\r\n/g, '\n').trim();
+    }
+}
+
+const UpdateModal: React.FC<UpdateModalProps> = ({ isOpen, onClose, onUpdate, version, downloading, progress, readyToInstall, releaseNotes }) => {
     if (!isOpen) return null;
+
+    const [showChangelog, setShowChangelog] = useState(false);
+    const changelogText = useMemo(() => {
+        const raw = normalizeReleaseNotes(releaseNotes);
+        const cleaned = toPlainText(raw);
+        return cleaned;
+    }, [releaseNotes]);
+
+    const hasChangelog = !downloading && !!changelogText;
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200">
@@ -49,6 +101,37 @@ const UpdateModal: React.FC<UpdateModalProps> = ({ isOpen, onClose, onUpdate, ve
                                     </p>
                                 </div>
                             </div>
+
+                            {hasChangelog && (
+                                <div className="mt-4">
+                                    <button
+                                        type="button"
+                                        className="w-full flex items-center justify-between rounded-lg border border-gray-200 dark:border-slate-700 bg-white/60 dark:bg-slate-900/40 px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-slate-900/60 transition-colors"
+                                        onClick={() => setShowChangelog(v => !v)}
+                                        aria-expanded={showChangelog}
+                                        aria-controls="update-changelog"
+                                    >
+                                        <div>
+                                            <div className="text-sm font-semibold text-slate-900 dark:text-white">Changelog</div>
+                                            <div className="text-xs text-slate-500 dark:text-slate-400">What\'s new in {version}</div>
+                                        </div>
+                                        <span className="text-slate-500 dark:text-slate-300">
+                                            {showChangelog ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+                                        </span>
+                                    </button>
+
+                                    {showChangelog && (
+                                        <div
+                                            id="update-changelog"
+                                            className="mt-2 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900/50 p-3 max-h-56 overflow-auto"
+                                        >
+                                            <pre className="whitespace-pre-wrap text-sm leading-5 text-slate-700 dark:text-slate-200 font-sans">
+                                                {changelogText}
+                                            </pre>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
                             
                             <div className="flex gap-3 justify-end mt-6">
                                 <Button variant="secondary" onClick={onClose}>


### PR DESCRIPTION
## Summary
- Adds a collapsible **Changelog** section to the update notification modal.
- Changelog is hidden by default and can be expanded by the user.

## UX
- Matches WinBorg's modal styling and uses a compact accordion row (with chevron).
- Release notes render as **safe plain text** (HTML stripped) inside a scrollable panel.

## Testing
- `npm test`
