### PR TITLE
chore(deps): bump TypeScript and patch security deps

### DIFF
--- a/e2e/main.spec.ts
+++ b/e2e/main.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect, _electron as electron } from '@playwright/test';
+import { test, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import path from 'path';
 import { addMockElectronInitScript } from './helpers/mockElectron';
 
 test.describe('@smoke WinBorg App Launch', () => {
-  let electronApp;
-  let firstWindow;
+  let electronApp: ElectronApplication | null;
+  let firstWindow: Page;
 
   test.beforeEach(async () => {
     // Launch Electron app.

--- a/e2e/onboarding.manual.spec.ts
+++ b/e2e/onboarding.manual.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { addMockElectronInitScript } from './helpers/mockElectron';
 
 test.describe('@manual Onboarding Flow (admin actions)', () => {
-  let electronApp: ElectronApplication;
+  let electronApp: ElectronApplication | null;
   let firstWindow: Page;
 
   test.beforeEach(async () => {

--- a/e2e/onboarding.manual.spec.ts
+++ b/e2e/onboarding.manual.spec.ts
@@ -43,7 +43,7 @@ test.describe('@manual Onboarding Flow (admin actions)', () => {
       return;
     }
 
-    const appClosed = electronApp
+    const appClosed = electronApp!
       .waitForEvent('close', { timeout: 15000 })
       .then(() => 'closed' as const)
       .catch(() => null);

--- a/e2e/onboarding.manual.spec.ts
+++ b/e2e/onboarding.manual.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect, _electron as electron } from '@playwright/test';
+import { test, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import path from 'path';
 import { addMockElectronInitScript } from './helpers/mockElectron';
 
 test.describe('@manual Onboarding Flow (admin actions)', () => {
-  let electronApp;
-  let firstWindow;
+  let electronApp: ElectronApplication;
+  let firstWindow: Page;
 
   test.beforeEach(async () => {
     electronApp = await electron.launch({

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect, _electron as electron } from '@playwright/test';
+import { test, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import path from 'path';
 import { addMockElectronInitScript } from './helpers/mockElectron';
 
 test.describe('@smoke Onboarding Flow', () => {
-  let electronApp;
-  let firstWindow;
+  let electronApp: ElectronApplication | null;
+  let firstWindow: Page;
 
   test.beforeEach(async () => {
     // Launch app

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.2",
       "dependencies": {
         "electron-updater": "^6.8.3",
-        "nodemailer": "^8.0.4"
+        "nodemailer": "^8.0.5"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -76,16 +76,6 @@
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.28.5"
-      }
-    },
-    "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@actions/io": {
@@ -2815,16 +2805,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -8751,10 +8731,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
-      "license": "MIT-0",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -13624,6 +13603,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.4",
         "semantic-release": "^25.0.3",
-        "typescript": "^5.2.2",
+        "typescript": "^6.0.2",
         "vite": "^7.3.2",
         "vitest": "^4.0.17",
         "wait-on": "^9.0.4"
@@ -13599,9 +13599,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.4",
     "semantic-release": "^25.0.3",
-    "typescript": "^5.2.2",
+    "typescript": "^6.0.2",
     "vite": "^7.3.2",
     "vitest": "^4.0.17",
     "wait-on": "^9.0.4"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "electron-updater": "^6.8.3",
-    "nodemailer": "^8.0.4"
+    "nodemailer": "^8.0.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
@@ -103,7 +103,7 @@
     "wait-on": "^9.0.4"
   },
   "overrides": {
-    "undici": "6.23.0",
+    "undici": "6.24.0",
     "diff": "8.0.3"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -442,8 +442,8 @@ const App: React.FC = () => {
 
           const handleActivityLog = (_: any, log: ActivityLogEntry) => {
               const newLog: ActivityLogEntry = {
-                  id: crypto.randomUUID(),
                   ...log,
+                  id: crypto.randomUUID(),
                   time: log.time || new Date().toISOString()
               };
               setActivityLogs(prev => [newLog, ...prev].slice(0, 100));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -443,8 +443,8 @@ const App: React.FC = () => {
           const handleActivityLog = (_: any, log: ActivityLogEntry) => {
               const newLog: ActivityLogEntry = {
                   id: crypto.randomUUID(),
-                  time: new Date().toISOString(),
-                  ...log
+                  ...log,
+                  time: log.time || new Date().toISOString()
               };
               setActivityLogs(prev => [newLog, ...prev].slice(0, 100));
               if(log.status === 'success') toast.success(log.title);
@@ -544,7 +544,8 @@ const App: React.FC = () => {
           ...r,
           recoveryDrillState: {
               ...r.recoveryDrillState,
-              status: 'running',
+              status: 'running' as const,
+              lastRunAt: r.recoveryDrillState?.lastRunAt ?? 'Never',
               lastError: undefined
           }
       }) : r));

--- a/src/components/CreateBackupModal.test.tsx
+++ b/src/components/CreateBackupModal.test.tsx
@@ -25,7 +25,7 @@ const mockRepo: Repository = {
     name: 'Test Repo',
     url: 'ssh://test',
     status: 'connected',
-    lastBackup: null,
+    lastBackup: '',
     encryption: 'repokey',
     size: '0 B',
     fileCount: 0

--- a/src/services/borgService.ts
+++ b/src/services/borgService.ts
@@ -299,7 +299,7 @@ export const borgService = {
           // If remotePath is customized, we should try to use that binary instead of 'borg'
           const customBinary = overrides?.remotePath && overrides.remotePath !== 'borg' ? overrides.remotePath : 'borg';
           const sshArgs = [
-               '-p', parsed.port,
+               '-p', parsed.port || '22',
                ...(overrides?.disableHostCheck ? ['-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null'] : []),
                '-o', 'BatchMode=yes',
                userHost,
@@ -566,6 +566,7 @@ export const borgService = {
     if (!success) return [];
     try {
         const json = extractJson(listOutput);
+        if (!json) return [];
         const data = JSON.parse(json);
         return (data.archives || []).map((a: any) => ({
              id: a.id || a.name,

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -87,15 +87,16 @@ export const getNextRunForRepo = (jobs: BackupJob[], repoId: string): string | n
 
     if (!soonest) return null;
 
+    const next: Date = soonest;
     // Formatting
-    const dayDiff = soonest.getDate() - now.getDate();
-    const timeStr = soonest.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const dayDiff = next.getDate() - now.getDate();
+    const timeStr = next.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
-    if (soonest.toDateString() === now.toDateString()) {
+    if (next.toDateString() === now.toDateString()) {
         return `Today ${timeStr}`;
     } else if (dayDiff === 1 || (dayDiff === -30)) { // Simple check for tomorrow (ignoring exact month wrap edge cases for UI simplicity)
         return `Tomorrow ${timeStr}`;
     } else {
-        return `${soonest.toLocaleDateString()} ${timeStr}`;
+        return `${next.toLocaleDateString()} ${timeStr}`;
     }
 };

--- a/src/views/DashboardView.test.tsx
+++ b/src/views/DashboardView.test.tsx
@@ -163,7 +163,7 @@ describe('DashboardView', () => {
     expect(mockIpcRenderer.on).toHaveBeenCalledWith('terminal-log', expect.any(Function));
     
     // Simulate event
-    const callback = mockIpcRenderer.on.mock.calls.find(call => call[0] === 'terminal-log')[1];
+    const callback = mockIpcRenderer.on.mock.calls.find((call: any[]) => call[0] === 'terminal-log')![1];
     
     act(() => {
       callback({}, { text: 'A /home/user/newfile.txt' });

--- a/src/views/JobsView.test.tsx
+++ b/src/views/JobsView.test.tsx
@@ -33,7 +33,7 @@ describe('JobsView', () => {
       encryption: 'none',
       status: 'connected',
       checkStatus: 'idle',
-      lastBackup: null,
+      lastBackup: '',
       size: '0 B',
       fileCount: 0,
     };
@@ -62,7 +62,7 @@ describe('JobsView', () => {
       encryption: 'none',
       status: 'connected',
       checkStatus: 'idle',
-      lastBackup: null,
+      lastBackup: '',
       size: '0 B',
       fileCount: 0,
     };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- bump TypeScript to 6.0.2 (existing branch scope)
- bump nodemailer to 8.0.5 (fixes alert #63)
- bump undici override to 6.24.0 (fixes alerts #28, #29, #30)

## Validation
- npm ls undici nodemailer --all
- npm audit --omit=dev (0 vulnerabilities)
- npm run typecheck

## Release behavior
- This uses a chore commit message and does not trigger a semantic version release on its own.
- Semantic Release only runs on pushes to main.