### PR TITLE
fix: ensure SSH key files end with trailing newline on import

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -18,7 +18,7 @@ const {
     isWithinActiveScheduleWindow,
 } = require('./main/scheduler');
 const { createSystemHandlers } = require('./main/systemHandlers');
-const { resolveSshKeyInstallOptions } = require('./main/sshHelpers');
+const { resolveSshKeyInstallOptions, normalizeSshKey } = require('./main/sshHelpers');
 const { createMountPreflight } = require('./main/mountPreflight');
 
 // --- TEST MODE: isolate userData so repeated E2E launches don't fight the single-instance lock.
@@ -1818,11 +1818,11 @@ ipcMain.handle('ssh-key-manage', async (event, { action, type, privateKey, publi
             await runWsl('mkdir -p ~/.ssh && chmod 700 ~/.ssh');
 
             // Write private key with restrictive perms (umask 077)
-            await wslWriteFile(wslBaseArgs, keyFile, priv.replace(/\r\n/g, '\n'));
+            await wslWriteFile(wslBaseArgs, keyFile, normalizeSshKey(priv));
 
             if (pub.trim()) {
                 // Public key is not sensitive, but we still keep perms reasonably strict.
-                await wslWriteFile(wslBaseArgs, keyFilePub, pub.replace(/\r\n/g, '\n'), { restrictPerms: false });
+                await wslWriteFile(wslBaseArgs, keyFilePub, normalizeSshKey(pub), { restrictPerms: false });
             } else {
                 // Derive public key from private key.
                 const res = await runWsl(`ssh-keygen -y -f ${keyFile} > ${keyFilePub}`);

--- a/main/sshHelpers.js
+++ b/main/sshHelpers.js
@@ -26,8 +26,19 @@ function resolveSshKeyInstallOptions(target, port) {
     };
 }
 
+/**
+ * Normalize an SSH key string for writing to disk:
+ * - Convert Windows (CRLF) and old-Mac (CR) line endings to Unix (LF)
+ * - Ensure the content ends with exactly one newline (required by OpenSSH / libcrypto)
+ */
+function normalizeSshKey(key) {
+    const s = String(key).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    return s.endsWith('\n') ? s : s + '\n';
+}
+
 module.exports = {
     isHetznerStorageBoxTarget,
     extractRemoteUser,
     resolveSshKeyInstallOptions,
+    normalizeSshKey,
 };

--- a/src/test/sshHelpers.test.ts
+++ b/src/test/sshHelpers.test.ts
@@ -6,6 +6,7 @@ const {
     isHetznerStorageBoxTarget,
     extractRemoteUser,
     resolveSshKeyInstallOptions,
+    normalizeSshKey,
 } = require('../../main/sshHelpers');
 
 describe('sshHelpers', () => {
@@ -40,6 +41,47 @@ describe('sshHelpers', () => {
             isHetzner: false,
             finalPort: undefined,
             remoteUser: 'user',
+        });
+    });
+
+    describe('normalizeSshKey', () => {
+        const PRIV_KEY_NO_NL =
+            '-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZ\n-----END OPENSSH PRIVATE KEY-----';
+        const PRIV_KEY_WITH_NL = PRIV_KEY_NO_NL + '\n';
+
+        it('appends trailing newline when missing', () => {
+            expect(normalizeSshKey(PRIV_KEY_NO_NL)).toBe(PRIV_KEY_WITH_NL);
+        });
+
+        it('preserves existing trailing newline (no double newline)', () => {
+            expect(normalizeSshKey(PRIV_KEY_WITH_NL)).toBe(PRIV_KEY_WITH_NL);
+        });
+
+        it('converts CRLF to LF', () => {
+            const crlf = '-----BEGIN OPENSSH PRIVATE KEY-----\r\ndata\r\n-----END OPENSSH PRIVATE KEY-----\r\n';
+            const result = normalizeSshKey(crlf);
+            expect(result).not.toContain('\r');
+            expect(result).toBe('-----BEGIN OPENSSH PRIVATE KEY-----\ndata\n-----END OPENSSH PRIVATE KEY-----\n');
+        });
+
+        it('converts standalone CR to LF', () => {
+            const cr = 'line1\rline2\rline3';
+            const result = normalizeSshKey(cr);
+            expect(result).toBe('line1\nline2\nline3\n');
+        });
+
+        it('handles trimmed key (no trailing newline after trim)', () => {
+            const trimmed = '-----BEGIN OPENSSH PRIVATE KEY-----\ndata\n-----END OPENSSH PRIVATE KEY-----'.trim();
+            const result = normalizeSshKey(trimmed);
+            expect(result.endsWith('\n')).toBe(true);
+            expect(result.endsWith('\n\n')).toBe(false);
+        });
+
+        it('handles key with CRLF and no trailing newline', () => {
+            const key = '-----BEGIN OPENSSH PRIVATE KEY-----\r\ndata\r\n-----END OPENSSH PRIVATE KEY-----';
+            const result = normalizeSshKey(key);
+            expect(result.endsWith('\n')).toBe(true);
+            expect(result).not.toContain('\r');
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #158 — Importing an existing SSH key via the UI causes connection failure due to missing trailing newline.

## Root Cause

When pasting SSH keys into the import dialog, the frontend calls `.trim()` on the key content (in `ConnectionsView.tsx` lines 296-297), which strips the trailing newline. OpenSSH / libcrypto requires PEM-formatted key files to end with a newline character (`\n`). Without it, `ssh` fails with:

```
Load key "/root/.ssh/id_ed25519": error in libcrypto
```

## Fix

Extracted a `normalizeSshKey()` utility into `main/sshHelpers.js` that:
- Converts Windows (CRLF) and old-Mac (CR) line endings to Unix (LF)
- Ensures the content always ends with exactly one `\n`

Applied `normalizeSshKey()` to both private and public key content in the `ssh-key-manage` IPC handler (`electron-main.js`) before writing keys to disk. This ensures correctness regardless of how the frontend processes the input.

## Changes

| File | Change |
|---|---|
| `main/sshHelpers.js` | Added `normalizeSshKey()` function and exported it |
| `electron-main.js` | Import and use `normalizeSshKey()` when writing SSH keys |
| `src/test/sshHelpers.test.ts` | Added 6 unit tests covering all edge cases |

## Tests

All 232 tests pass (including 6 new tests for the fix):
- Missing trailing newline → appended
- Existing trailing newline → preserved (no double newline)  
- CRLF line endings → converted to LF
- Standalone CR → converted to LF
- Trimmed key input → newline appended
- CRLF without trailing newline → normalized and newline appended