### PR TITLE
feat: configurable hour interval for scheduled backups

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -32,6 +32,8 @@ The following list is derived from `electron-main.js` IPC registrations.
 
 - `get-db` (invoke → DB snapshot)
 - `save-db` (invoke, payload: partial DB)
+- `sync-job-schedules` (invoke, payload: `{ previousJobs, nextJobs }`)
+- `get-job-schedule-statuses` (invoke, payload: `{ jobs }`)
 - `export-app-data` (invoke, payload: `{ includeSecrets?: boolean }`)
 - `import-app-data` (invoke, payload: `{ includeSecrets?: boolean }`)
 

--- a/e2e/helpers/mockElectron.ts
+++ b/e2e/helpers/mockElectron.ts
@@ -320,6 +320,23 @@ export function addMockElectronInitScript(context: any, options: MockOptions = {
             // ensure defaults for repos when saved
             if (Array.isArray(state.db.repos)) state.db.repos = state.db.repos.map(ensureRepoDefaults);
             return { ok: true };
+          case 'sync-job-schedules':
+            return { success: true };
+          case 'get-job-schedule-statuses': {
+            const jobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
+            const statuses = Object.fromEntries(
+              jobs.map((job: any) => [
+                job.id,
+                {
+                  success: true,
+                  exists: !!job.scheduleEnabled,
+                  taskName: `WinBorg-${job.name || 'Job'}-${job.id}`,
+                  backend: job.scheduleBackend || 'winborg',
+                },
+              ])
+            );
+            return { success: true, statuses };
+          }
 
           case 'system-check-wsl':
             return {

--- a/e2e/jobs.spec.ts
+++ b/e2e/jobs.spec.ts
@@ -74,7 +74,7 @@ test.describe('Jobs flow', () => {
     // Enable schedule.
     await page.getByRole('button', { name: 'Schedule', exact: true }).click();
     await expect(page.getByText('Enable Schedule')).toBeVisible();
-    await page.locator('div', { has: page.getByText('Enable Schedule') }).locator('input[type="checkbox"]').check();
+    await page.getByRole('checkbox', { name: 'Enable Schedule' }).check();
 
     // Save job.
     await page.getByRole('button', { name: 'Save Job' }).click();

--- a/electron-main.js
+++ b/electron-main.js
@@ -9,6 +9,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 
+const { getScheduledJobIdFromArgv } = require('./main/launchArgs');
 const { safeReadJsonWithBackupSync, atomicWriteFileSync } = require('./main/persistence');
 const { createProcessManager } = require('./main/processManager');
 const {
@@ -17,6 +18,7 @@ const {
     finishJob,
     isWithinActiveScheduleWindow,
 } = require('./main/scheduler');
+const { createWindowsTaskScheduler } = require('./main/windowsTaskScheduler');
 const { createSystemHandlers } = require('./main/systemHandlers');
 const { resolveSshKeyInstallOptions, normalizeSshKey } = require('./main/sshHelpers');
 const { createMountPreflight } = require('./main/mountPreflight');
@@ -50,6 +52,14 @@ if (!isTestMode) {
         // This is the first instance.
         // Set up a listener for any subsequent attempts to launch a second instance.
         app.on('second-instance', (event, commandLine, workingDirectory) => {
+            const scheduledJobId = getScheduledJobIdFromArgv(commandLine);
+            if (scheduledJobId) {
+                executeScheduledJobById(scheduledJobId).catch((error) => {
+                    console.error('[Scheduler] Failed to execute scheduled job from second instance', error);
+                });
+                return;
+            }
+
             // Someone tried to run a second instance. We should focus our window.
             if (mainWindow) {
                 if (mainWindow.isMinimized()) mainWindow.restore();
@@ -159,6 +169,11 @@ const {
     spawnCapture,
 } = processManager;
 
+const windowsTaskScheduler = createWindowsTaskScheduler({
+    spawnCapture,
+    logger: console,
+});
+
 // --- PERSISTENCE PATHS ---
 const userDataPath = app.getPath('userData');
 const secretsPath = path.join(userDataPath, 'secrets.json');
@@ -198,6 +213,23 @@ function safeSendToRenderer(channel, payload) {
     } catch (e) {
         // Best-effort only
     }
+}
+
+function getTaskSchedulerLaunchContext() {
+    const exePath = app.getPath('exe');
+    const candidateAppPath = (typeof app.getAppPath === 'function') ? app.getAppPath() : null;
+    const appPathArg = !app.isPackaged && candidateAppPath && fs.existsSync(candidateAppPath)
+        ? candidateAppPath
+        : null;
+
+    return {
+        executablePath: exePath,
+        appPathArg,
+    };
+}
+
+async function syncWindowsTaskSchedulerJobs(previousJobs = [], nextJobs = []) {
+    return windowsTaskScheduler.syncJobs(previousJobs, nextJobs, getTaskSchedulerLaunchContext());
 }
 
 async function wslWriteFile(wslBaseArgs, filePath, content, { timeoutMs = 30000, restrictPerms = true } = {}) {
@@ -795,10 +827,12 @@ function startScheduler() {
 async function executeBackgroundJob(job) {
     if (!tryStartJob(job.id, runningBackgroundJobIds)) {
         console.log(`[Scheduler] Job already running, skipping: ${job.name}`);
-        return;
+        return { success: false, skipped: true, reason: 'already-running' };
     }
 
     console.log(`[Scheduler] Triggering Job: ${job.name}`);
+
+    let overallSuccess = false;
 
     try {
 
@@ -814,7 +848,7 @@ async function executeBackgroundJob(job) {
                 body: `Job '${job.name}' put on hold (On Battery).`,
                 silent: true 
             }).show();
-            return;
+            return { success: false, skipped: true, reason: 'battery' };
         }
     }
 
@@ -823,13 +857,13 @@ async function executeBackgroundJob(job) {
         if (!net.online) {
              console.log(`[Scheduler] Skipped job ${job.name} because device is offline.`);
              // Silent skip, no notification needed for offline usually
-             return;
+             return { success: false, skipped: true, reason: 'offline' };
         }
     }
 
     const repo = availableRepos.find(r => r.id === job.repoId);
     if (!repo) {
-        return;
+        return { success: false, error: 'repo-not-found' };
     }
 
     // Provide a stable, renderer-visible id so scheduled jobs can be surfaced (ETA/status)
@@ -870,7 +904,7 @@ async function executeBackgroundJob(job) {
             icon: getIconPath() || undefined
         }).show();
         safeSendToRenderer('job-complete', { jobId: job.id, repoId: repo.id, commandId, success: false });
-        return;
+        return { success: false, error: 'no-source-paths' };
     }
 
     const sourcePathsForCreate = useWsl
@@ -976,6 +1010,7 @@ async function executeBackgroundJob(job) {
         }).show();
         dispatchNotifications(job.name, true, `Archive created: ${archiveName}${pruneSummary}\n\n${getLastLines(createResult.output, 10)}`);
         safeSendToRenderer('job-complete', { jobId: job.id, repoId: repo.id, commandId, success: true });
+        overallSuccess = true;
         
     } else {
         new Notification({ 
@@ -988,10 +1023,24 @@ async function executeBackgroundJob(job) {
         safeSendToRenderer('job-complete', { jobId: job.id, repoId: repo.id, commandId, success: false });
     }
 
+    return { success: overallSuccess };
+
     } finally {
         activeScheduledJobCommands.delete(job.id);
         finishJob(job.id, runningBackgroundJobIds);
     }
+}
+
+async function executeScheduledJobById(jobId) {
+    if (!jobId) return { success: false, error: 'missing-job-id' };
+
+    const job = scheduledJobs.find((candidate) => candidate && candidate.id === jobId);
+    if (!job) {
+        console.warn(`[Scheduler] Scheduled task requested unknown job: ${jobId}`);
+        return { success: false, error: 'job-not-found' };
+    }
+
+    return executeBackgroundJob(job);
 }
 
 function getLastLines(text, count) {
@@ -1210,10 +1259,26 @@ app.whenReady().then(() => {
         });
     });
 
+    const scheduledJobId = getScheduledJobIdFromArgv(process.argv);
     const shouldStartMinimized = process.argv.includes('--hidden');
+
+    if (scheduledJobId) {
+        executeScheduledJobById(scheduledJobId)
+            .catch((error) => {
+                console.error('[Scheduler] Scheduled task launch failed', error);
+            })
+            .finally(() => {
+                cleanupAndQuit();
+            });
+        return;
+    }
+
     createWindow(shouldStartMinimized);
     createTray();
     startScheduler();
+    syncWindowsTaskSchedulerJobs([], scheduledJobs).catch((error) => {
+        console.warn('[TaskScheduler] Startup reconciliation failed', error);
+    });
     powerMonitor.on('resume', () => {
         runSchedulerTick({ allowCatchUp: true });
     });
@@ -1369,6 +1434,8 @@ ipcMain.handle('import-app-data', async (event, { includeSecrets } = { includeSe
         scheduleStrict: false
     };
 
+    const previousJobs = Array.isArray(dbCache.jobs) ? dbCache.jobs : [];
+
     dbCache = normalizeDbCache({
         ...dbCache,
         ...importedDb,
@@ -1387,6 +1454,11 @@ ipcMain.handle('import-app-data', async (event, { includeSecrets } = { includeSe
     persistDb();
     persistNotifications();
     if (includeSecrets && importedSecrets) persistSecrets();
+
+    const taskSyncResult = await syncWindowsTaskSchedulerJobs(previousJobs, dbCache.jobs || []);
+    if (!taskSyncResult.success) {
+        console.warn('[TaskScheduler] Import sync failed:', taskSyncResult.error);
+    }
 
     syncRuntimeStateFromDb();
 
@@ -1420,6 +1492,14 @@ ipcMain.on('sync-scheduler-data', (event, { jobs, repos }) => {
     dbCache.repos = repos;
     persistDb();
     updateTrayMenu();
+});
+
+ipcMain.handle('sync-job-schedules', async (event, { previousJobs, nextJobs }) => {
+    return await syncWindowsTaskSchedulerJobs(previousJobs, nextJobs);
+});
+
+ipcMain.handle('get-job-schedule-statuses', async (event, { jobs }) => {
+    return await windowsTaskScheduler.getJobStatuses(jobs);
 });
 
 // --- IPC HANDLERS ---

--- a/main/launchArgs.js
+++ b/main/launchArgs.js
@@ -1,0 +1,29 @@
+function getArgValue(argv, flag) {
+    const list = Array.isArray(argv) ? argv : [];
+
+    for (let index = 0; index < list.length; index += 1) {
+        const value = list[index];
+        if (typeof value !== 'string') continue;
+
+        if (value === flag) {
+            const nextValue = list[index + 1];
+            return typeof nextValue === 'string' && nextValue.trim() ? nextValue.trim() : null;
+        }
+
+        if (value.startsWith(`${flag}=`)) {
+            const inlineValue = value.slice(flag.length + 1).trim();
+            return inlineValue || null;
+        }
+    }
+
+    return null;
+}
+
+function getScheduledJobIdFromArgv(argv) {
+    return getArgValue(argv, '--run-scheduled-job');
+}
+
+module.exports = {
+    getArgValue,
+    getScheduledJobIdFromArgv,
+};

--- a/main/scheduler.js
+++ b/main/scheduler.js
@@ -24,6 +24,12 @@ function parseTimeToMinutes(value) {
     return (hours * 60) + minutes;
 }
 
+function parseWeekday(value) {
+    if (!Number.isInteger(value)) return null;
+    if (value < 0 || value > 6) return null;
+    return value;
+}
+
 function isWithinActiveScheduleWindow(now, settings) {
     if (!settings || settings.scheduleEnabled !== true) return true;
 
@@ -53,8 +59,35 @@ function getScheduledSlotTime(job, now) {
     }
 
     if (job.scheduleType === 'hourly') {
+        const scheduleMinutes = parseTimeToMinutes(job.scheduleTime || '00:00');
+        if (scheduleMinutes === null) return null;
+
         const slot = new Date(now);
-        slot.setMinutes(0, 0, 0);
+        slot.setMinutes(scheduleMinutes % 60, 0, 0);
+
+        if (slot <= now) {
+            return slot;
+        }
+
+        slot.setHours(slot.getHours() - 1);
+        return slot;
+    }
+
+    if (job.scheduleType === 'weekly') {
+        const scheduleMinutes = parseTimeToMinutes(job.scheduleTime);
+        const scheduleWeekday = parseWeekday(job.scheduleWeekday);
+        if (scheduleMinutes === null || scheduleWeekday === null) return null;
+
+        const slot = new Date(now);
+        const daysSinceScheduledWeekday = (now.getDay() - scheduleWeekday + 7) % 7;
+        slot.setDate(slot.getDate() - daysSinceScheduledWeekday);
+        slot.setHours(Math.floor(scheduleMinutes / 60), scheduleMinutes % 60, 0, 0);
+
+        if (slot <= now) {
+            return slot;
+        }
+
+        slot.setDate(slot.getDate() - 7);
         return slot;
     }
 
@@ -69,6 +102,9 @@ function parseLastRunAt(lastRunAt) {
 
 function shouldTriggerScheduledJob(job, now, lastKey, options = {}) {
     if (!job || !job.scheduleEnabled) return { shouldTrigger: false, triggerKey: null };
+    if (job.scheduleBackend === 'windows-task-scheduler') {
+        return { shouldTrigger: false, triggerKey: null };
+    }
     if (!isWithinActiveScheduleWindow(now, options.scheduleWindow)) {
         return { shouldTrigger: false, triggerKey: null };
     }

--- a/main/scheduler.js
+++ b/main/scheduler.js
@@ -62,14 +62,20 @@ function getScheduledSlotTime(job, now) {
         const scheduleMinutes = parseTimeToMinutes(job.scheduleTime || '00:00');
         if (scheduleMinutes === null) return null;
 
+        const minute = scheduleMinutes % 60;
+        const interval = (Number.isInteger(job.scheduleHourInterval) && job.scheduleHourInterval > 1)
+            ? job.scheduleHourInterval
+            : 1;
+
         const slot = new Date(now);
-        slot.setMinutes(scheduleMinutes % 60, 0, 0);
+        const slotHour = Math.floor(now.getHours() / interval) * interval;
+        slot.setHours(slotHour, minute, 0, 0);
 
         if (slot <= now) {
             return slot;
         }
 
-        slot.setHours(slot.getHours() - 1);
+        slot.setHours(slotHour - interval, minute, 0, 0);
         return slot;
     }
 

--- a/main/windowsTaskScheduler.js
+++ b/main/windowsTaskScheduler.js
@@ -45,7 +45,12 @@ function getTaskNameForJob(job) {
 }
 
 function quoteWindowsCommandArg(value) {
-    return `"${String(value ?? '').replace(/"/g, '\\"')}"`;
+    const rawValue = String(value ?? '');
+    const escapedValue = rawValue
+        .replace(/(\\*)"/g, '$1$1\\"')
+        .replace(/(\\+)$/g, '$1$1');
+
+    return `"${escapedValue}"`;
 }
 
 function buildTaskRunCommand(launchContext, jobId) {
@@ -308,6 +313,7 @@ module.exports = {
     buildCreateTaskArgs,
     buildDeleteTaskArgs,
     buildQueryTaskArgs,
+    quoteWindowsCommandArg,
     createWindowsTaskScheduler,
     shouldTrackWindowsTask,
 };

--- a/main/windowsTaskScheduler.js
+++ b/main/windowsTaskScheduler.js
@@ -1,0 +1,313 @@
+const WINBORG_SCHEDULER_BACKEND = 'winborg';
+const WINDOWS_TASK_SCHEDULER_BACKEND = 'windows-task-scheduler';
+
+const WEEKDAY_MAP = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+
+function sanitizeTaskNameSegment(value, fallback = 'job') {
+    const clean = String(value || '')
+        .replace(/[<>:"/\\|?*\x00-\x1F]/g, '_')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    return clean || fallback;
+}
+
+function getScheduleBackend(job) {
+    return job && job.scheduleBackend === WINDOWS_TASK_SCHEDULER_BACKEND
+        ? WINDOWS_TASK_SCHEDULER_BACKEND
+        : WINBORG_SCHEDULER_BACKEND;
+}
+
+function shouldUseWindowsTaskScheduler(job) {
+    return !!job && job.scheduleEnabled === true && getScheduleBackend(job) === WINDOWS_TASK_SCHEDULER_BACKEND;
+}
+
+function shouldTrackWindowsTask(job) {
+    return !!job && getScheduleBackend(job) === WINDOWS_TASK_SCHEDULER_BACKEND;
+}
+
+function normalizeScheduleTime(value, fallback = '00:00') {
+    if (typeof value === 'string' && /^\d{2}:\d{2}$/.test(value)) {
+        return value;
+    }
+
+    return fallback;
+}
+
+function getWeekdayToken(weekday) {
+    if (!Number.isInteger(weekday) || weekday < 0 || weekday > 6) return WEEKDAY_MAP[0];
+    return WEEKDAY_MAP[weekday];
+}
+
+function getTaskNameForJob(job) {
+    const name = sanitizeTaskNameSegment(job && job.name, 'Job');
+    return `WinBorg-${name}-${job && job.id ? job.id : 'unknown'}`;
+}
+
+function quoteWindowsCommandArg(value) {
+    return `"${String(value ?? '').replace(/"/g, '\\"')}"`;
+}
+
+function buildTaskRunCommand(launchContext, jobId) {
+    if (!launchContext || !launchContext.executablePath) {
+        throw new Error('Missing WinBorg launch context for Task Scheduler command.');
+    }
+
+    const args = [];
+    if (launchContext.appPathArg) args.push(launchContext.appPathArg);
+    args.push('--hidden', '--run-scheduled-job', jobId, '--scheduler-source', WINDOWS_TASK_SCHEDULER_BACKEND);
+
+    return [launchContext.executablePath, ...args].map(quoteWindowsCommandArg).join(' ');
+}
+
+function buildTaskScheduleArgs(job) {
+    const scheduleType = job && job.scheduleType;
+
+    if (scheduleType === 'daily') {
+        return ['/SC', 'DAILY', '/ST', normalizeScheduleTime(job.scheduleTime, '14:00')];
+    }
+
+    if (scheduleType === 'hourly') {
+        const [, minute] = normalizeScheduleTime(job.scheduleTime, '00:00').split(':');
+        return ['/SC', 'HOURLY', '/MO', '1', '/ST', `00:${minute}`];
+    }
+
+    if (scheduleType === 'weekly') {
+        return [
+            '/SC', 'WEEKLY',
+            '/D', getWeekdayToken(job && job.scheduleWeekday),
+            '/ST', normalizeScheduleTime(job.scheduleTime, '14:00')
+        ];
+    }
+
+    return null;
+}
+
+function buildCreateTaskArgs(job, launchContext) {
+    const scheduleArgs = buildTaskScheduleArgs(job);
+    if (!scheduleArgs) {
+        throw new Error(`Unsupported Task Scheduler schedule type: ${job && job.scheduleType}`);
+    }
+
+    return [
+        '/Create',
+        '/TN', getTaskNameForJob(job),
+        '/TR', buildTaskRunCommand(launchContext, job.id),
+        ...scheduleArgs,
+        '/F'
+    ];
+}
+
+function buildDeleteTaskArgs(job) {
+    return ['/Delete', '/TN', getTaskNameForJob(job), '/F'];
+}
+
+function buildQueryTaskArgs(job) {
+    return ['/Query', '/TN', getTaskNameForJob(job)];
+}
+
+function getTaskSchedulerError(result, fallback) {
+    const detail = [result && result.stderr, result && result.stdout, result && result.error]
+        .filter(Boolean)
+        .map((value) => String(value).trim())
+        .find(Boolean);
+
+    return detail || fallback;
+}
+
+function isTaskMissing(result) {
+    const detail = `${result && result.stderr ? result.stderr : ''}\n${result && result.stdout ? result.stdout : ''}\n${result && result.error ? result.error : ''}`.toLowerCase();
+    return detail.includes('cannot find') || detail.includes('does not exist') || detail.includes('cannot find the file specified');
+}
+
+function createWindowsTaskScheduler({ spawnCapture, platform = process.platform, logger = console } = {}) {
+    async function upsertJob(job, launchContext) {
+        if (!shouldUseWindowsTaskScheduler(job)) {
+            return { success: true, skipped: true };
+        }
+
+        if (platform !== 'win32') {
+            return { success: false, error: 'Windows Task Scheduler is only available on Windows.' };
+        }
+
+        if (!launchContext || !launchContext.executablePath) {
+            return { success: false, error: 'WinBorg launch context could not be resolved.' };
+        }
+
+        try {
+            const result = await spawnCapture('schtasks.exe', buildCreateTaskArgs(job, launchContext), { timeoutMs: 30000 });
+            if (result.error || result.code !== 0) {
+                return {
+                    success: false,
+                    error: getTaskSchedulerError(result, `Failed to create scheduled task for ${job.name}.`),
+                    taskName: getTaskNameForJob(job),
+                };
+            }
+
+            return { success: true, taskName: getTaskNameForJob(job) };
+        } catch (error) {
+            logger.warn && logger.warn('[TaskScheduler] Failed to create or update task', error);
+            return { success: false, error: error && error.message ? error.message : String(error) };
+        }
+    }
+
+    async function deleteJob(job) {
+        if (!job || getScheduleBackend(job) !== WINDOWS_TASK_SCHEDULER_BACKEND) {
+            return { success: true, skipped: true };
+        }
+
+        if (platform !== 'win32') {
+            return { success: true, skipped: true };
+        }
+
+        try {
+            const result = await spawnCapture('schtasks.exe', buildDeleteTaskArgs(job), { timeoutMs: 30000 });
+            if (result.error || (result.code !== 0 && !isTaskMissing(result))) {
+                return {
+                    success: false,
+                    error: getTaskSchedulerError(result, `Failed to delete scheduled task for ${job.name}.`),
+                    taskName: getTaskNameForJob(job),
+                };
+            }
+
+            return { success: true, taskName: getTaskNameForJob(job) };
+        } catch (error) {
+            logger.warn && logger.warn('[TaskScheduler] Failed to delete task', error);
+            return { success: false, error: error && error.message ? error.message : String(error) };
+        }
+    }
+
+    async function syncJobs(previousJobs = [], nextJobs = [], launchContext) {
+        const previousExternalJobs = (Array.isArray(previousJobs) ? previousJobs : []).filter(shouldUseWindowsTaskScheduler);
+        const nextExternalJobs = (Array.isArray(nextJobs) ? nextJobs : []).filter(shouldUseWindowsTaskScheduler);
+
+        if (platform !== 'win32') {
+            if (nextExternalJobs.length > 0) {
+                return { success: false, error: 'Windows Task Scheduler is only available on Windows.' };
+            }
+
+            return { success: true, skipped: true };
+        }
+
+        const nextTaskNames = new Set(nextExternalJobs.map((job) => getTaskNameForJob(job)));
+        const failures = [];
+
+        for (const previousJob of previousExternalJobs) {
+            const previousTaskName = getTaskNameForJob(previousJob);
+            if (nextTaskNames.has(previousTaskName)) continue;
+
+            const deletion = await deleteJob(previousJob);
+            if (!deletion.success) failures.push(deletion);
+        }
+
+        for (const nextJob of nextExternalJobs) {
+            const syncResult = await upsertJob(nextJob, launchContext);
+            if (!syncResult.success) failures.push(syncResult);
+        }
+
+        if (failures.length > 0) {
+            return {
+                success: false,
+                error: failures[0].error || 'Failed to synchronize one or more Windows scheduled tasks.',
+                details: failures,
+            };
+        }
+
+        return { success: true };
+    }
+
+    async function queryJob(job) {
+        if (!shouldTrackWindowsTask(job)) {
+            return {
+                success: true,
+                skipped: true,
+                taskName: getTaskNameForJob(job),
+                backend: getScheduleBackend(job),
+            };
+        }
+
+        if (platform !== 'win32') {
+            return {
+                success: true,
+                unsupported: true,
+                exists: false,
+                taskName: getTaskNameForJob(job),
+                backend: getScheduleBackend(job),
+            };
+        }
+
+        try {
+            const result = await spawnCapture('schtasks.exe', buildQueryTaskArgs(job), { timeoutMs: 30000 });
+            if (result.error || result.code !== 0) {
+                if (isTaskMissing(result)) {
+                    return {
+                        success: true,
+                        exists: false,
+                        taskName: getTaskNameForJob(job),
+                        backend: getScheduleBackend(job),
+                    };
+                }
+
+                return {
+                    success: false,
+                    exists: false,
+                    error: getTaskSchedulerError(result, `Failed to query scheduled task for ${job.name}.`),
+                    taskName: getTaskNameForJob(job),
+                    backend: getScheduleBackend(job),
+                };
+            }
+
+            return {
+                success: true,
+                exists: true,
+                taskName: getTaskNameForJob(job),
+                backend: getScheduleBackend(job),
+            };
+        } catch (error) {
+            logger.warn && logger.warn('[TaskScheduler] Failed to query task', error);
+            return {
+                success: false,
+                exists: false,
+                error: error && error.message ? error.message : String(error),
+                taskName: getTaskNameForJob(job),
+                backend: getScheduleBackend(job),
+            };
+        }
+    }
+
+    async function getJobStatuses(jobs = []) {
+        const trackedJobs = (Array.isArray(jobs) ? jobs : []).filter(shouldTrackWindowsTask);
+        const statuses = {};
+
+        for (const job of trackedJobs) {
+            statuses[job.id] = await queryJob(job);
+        }
+
+        return { success: true, statuses };
+    }
+
+    return {
+        upsertJob,
+        deleteJob,
+        syncJobs,
+        queryJob,
+        getJobStatuses,
+    };
+}
+
+module.exports = {
+    WINBORG_SCHEDULER_BACKEND,
+    WINDOWS_TASK_SCHEDULER_BACKEND,
+    sanitizeTaskNameSegment,
+    getScheduleBackend,
+    shouldUseWindowsTaskScheduler,
+    getWeekdayToken,
+    getTaskNameForJob,
+    buildTaskRunCommand,
+    buildTaskScheduleArgs,
+    buildCreateTaskArgs,
+    buildDeleteTaskArgs,
+    buildQueryTaskArgs,
+    createWindowsTaskScheduler,
+    shouldTrackWindowsTask,
+};

--- a/main/windowsTaskScheduler.js
+++ b/main/windowsTaskScheduler.js
@@ -74,7 +74,10 @@ function buildTaskScheduleArgs(job) {
 
     if (scheduleType === 'hourly') {
         const [, minute] = normalizeScheduleTime(job.scheduleTime, '00:00').split(':');
-        return ['/SC', 'HOURLY', '/MO', '1', '/ST', `00:${minute}`];
+        const interval = (Number.isInteger(job && job.scheduleHourInterval) && job.scheduleHourInterval > 1)
+            ? job.scheduleHourInterval
+            : 1;
+        return ['/SC', 'HOURLY', '/MO', String(interval), '/ST', `00:${minute}`];
     }
 
     if (scheduleType === 'weekly') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -624,6 +624,38 @@ const App: React.FC = () => {
       reposRef.current = repos;
   }, [repos]);
 
+  const jobsRef = useRef<BackupJob[]>([]);
+  useEffect(() => {
+      jobsRef.current = jobs;
+  }, [jobs]);
+
+  const syncJobSchedules = async (previousJobs: BackupJob[], nextJobs: BackupJob[]) => {
+      const result = await borgService.syncJobSchedules(previousJobs, nextJobs);
+      if (!result?.success) {
+          toast.error(result?.error || 'Failed to update scheduled task configuration.');
+          return { ok: false, jobs: previousJobs };
+      }
+
+      const syncedAt = new Date().toISOString();
+      const normalizedJobs = nextJobs.map((job) => {
+          if (job.scheduleBackend === 'windows-task-scheduler') {
+              return {
+                  ...job,
+                  scheduleTaskLastSyncedAt: syncedAt,
+              };
+          }
+
+          if (job.scheduleTaskLastSyncedAt !== undefined) {
+              const { scheduleTaskLastSyncedAt, ...rest } = job;
+              return rest;
+          }
+
+          return job;
+      });
+
+      return { ok: true, jobs: normalizedJobs };
+  };
+
   // Mount Listener
   useEffect(() => {
     try {
@@ -1118,6 +1150,11 @@ const App: React.FC = () => {
 
   const handleDeleteRepo = async (repoId: string) => {
       if (window.confirm("Remove this repository?")) {
+          const previousJobs = jobsRef.current;
+          const nextJobs = previousJobs.filter(j => j.repoId !== repoId);
+          const syncResult = await syncJobSchedules(previousJobs, nextJobs);
+          if (!syncResult.ok) return;
+
           // Clean up secret
           await borgService.deletePassphrase(repoId);
           setRepos(prev => prev.filter(r => r.id !== repoId));
@@ -1127,19 +1164,37 @@ const App: React.FC = () => {
       }
   };
 
-  const handleAddJob = (job: BackupJob) => {
-      setJobs(prev => [...prev, job]);
+  const handleAddJob = async (job: BackupJob) => {
+      const previousJobs = jobsRef.current;
+      const nextJobs = [...previousJobs, job];
+      const syncResult = await syncJobSchedules(previousJobs, nextJobs);
+      if (!syncResult.ok) return false;
+
+      setJobs(syncResult.jobs);
       toast.success("Backup Job created.");
+      return true;
   };
 
-  const handleUpdateJob = (job: BackupJob) => {
-      setJobs(prev => prev.map(j => j.id === job.id ? job : j));
+  const handleUpdateJob = async (job: BackupJob) => {
+      const previousJobs = jobsRef.current;
+      const nextJobs = previousJobs.map(j => j.id === job.id ? job : j);
+      const syncResult = await syncJobSchedules(previousJobs, nextJobs);
+      if (!syncResult.ok) return false;
+
+      setJobs(syncResult.jobs);
       toast.success("Backup Job updated.");
+      return true;
   };
 
-  const handleDeleteJob = (jobId: string) => {
-      setJobs(prev => prev.filter(j => j.id !== jobId));
+  const handleDeleteJob = async (jobId: string) => {
+      const previousJobs = jobsRef.current;
+      const nextJobs = previousJobs.filter(j => j.id !== jobId);
+      const syncResult = await syncJobSchedules(previousJobs, nextJobs);
+      if (!syncResult.ok) return false;
+
+      setJobs(syncResult.jobs);
       toast.info("Backup Job deleted.");
+      return true;
   };
 
   const handleRunJob = async (jobId: string) => {

--- a/src/components/JobsModal.test.tsx
+++ b/src/components/JobsModal.test.tsx
@@ -1,16 +1,20 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 import JobsModal from './JobsModal';
 
 vi.mock('../services/borgService', () => ({
   borgService: {
     selectDirectory: vi.fn().mockResolvedValue(['C:\\Temp']),
+    getJobScheduleStatuses: vi.fn().mockResolvedValue({ success: true, statuses: {} }),
   },
 }));
 
+const { borgService } = await import('../services/borgService');
+
 describe('JobsModal', () => {
   it('creates a job and calls onAddJob with expected fields', async () => {
-    const onAddJob = vi.fn();
+    const onAddJob = vi.fn().mockResolvedValue(true);
 
     render(
       <JobsModal
@@ -47,7 +51,8 @@ describe('JobsModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save Job' }));
 
-    expect(onAddJob).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onAddJob).toHaveBeenCalledTimes(1));
+
     const jobArg = onAddJob.mock.calls[0][0];
 
     expect(jobArg.repoId).toBe('repo1');
@@ -56,5 +61,147 @@ describe('JobsModal', () => {
     expect(jobArg.sourcePaths).toEqual(['C:\\Temp']);
     // legacy field still populated
     expect(jobArg.sourcePath).toBe('C:\\Temp');
+  });
+
+  it('shows time controls for hourly and weekday plus time controls for weekly schedules', async () => {
+    render(
+      <JobsModal
+        repo={{
+          id: 'repo1',
+          name: 'My Repo',
+          url: 'ssh://user@example.com:22/./repo',
+          status: 'connected',
+          lastBackup: 'Never',
+          size: 'Unknown',
+          fileCount: 0,
+          encryption: 'repokey',
+        } as any}
+        jobs={[]}
+        isOpen={true}
+        onClose={() => {}}
+        onAddJob={() => {}}
+        onUpdateJob={() => {}}
+        onDeleteJob={() => {}}
+        onRunJob={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create First Job' }));
+    fireEvent.click(screen.getByRole('button', { name: /Schedule/i }));
+    fireEvent.click(screen.getByLabelText('Enable Schedule'));
+
+    fireEvent.change(screen.getByLabelText('Frequency'), { target: { value: 'hourly' } });
+    expect(screen.getByLabelText('Minute')).toBeInTheDocument();
+    expect(screen.getByText(/Runs once per hour at the selected minute/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Frequency'), { target: { value: 'weekly' } });
+    expect(screen.getByLabelText('Day')).toBeInTheDocument();
+    expect(screen.getByLabelText('Time')).toBeInTheDocument();
+  });
+
+  it('stores the Windows Task Scheduler backend when the checkbox is enabled', async () => {
+    const onAddJob = vi.fn().mockResolvedValue(true);
+
+    render(
+      <JobsModal
+        repo={{
+          id: 'repo1',
+          name: 'My Repo',
+          url: 'ssh://user@example.com:22/./repo',
+          status: 'connected',
+          lastBackup: 'Never',
+          size: 'Unknown',
+          fileCount: 0,
+          encryption: 'repokey',
+        } as any}
+        jobs={[]}
+        isOpen={true}
+        onClose={() => {}}
+        onAddJob={onAddJob}
+        onUpdateJob={() => {}}
+        onDeleteJob={() => {}}
+        onRunJob={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create First Job' }));
+    fireEvent.change(screen.getByPlaceholderText('e.g. My Documents'), { target: { value: 'Docs' } });
+    fireEvent.click(screen.getByRole('button', { name: /Add Folder/i }));
+    expect(await screen.findByText('C:\\Temp')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('e.g. docs'), { target: { value: 'docs' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Schedule/i }));
+    fireEvent.click(screen.getByLabelText('Enable Schedule'));
+    fireEvent.click(screen.getByLabelText('Use Windows Task Scheduler'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Job' }));
+
+    await waitFor(() => expect(onAddJob).toHaveBeenCalledTimes(1));
+    expect(onAddJob.mock.calls[0][0].scheduleBackend).toBe('windows-task-scheduler');
+  });
+
+  it('shows Windows Task status for existing external scheduler jobs', async () => {
+    vi.mocked(borgService.getJobScheduleStatuses).mockResolvedValueOnce({
+      success: true,
+      statuses: {
+        'job-1': {
+          success: true,
+          exists: true,
+          taskName: 'WinBorg-Docs-job-1',
+        },
+      },
+    });
+
+    render(
+      <JobsModal
+        repo={{
+          id: 'repo1',
+          name: 'My Repo',
+          url: 'ssh://user@example.com:22/./repo',
+          status: 'connected',
+          lastBackup: 'Never',
+          size: 'Unknown',
+          fileCount: 0,
+          encryption: 'repokey',
+        } as any}
+        jobs={[{
+          id: 'job-1',
+          repoId: 'repo1',
+          name: 'Docs',
+          archivePrefix: 'docs',
+          sourcePath: 'C:\\Temp',
+          sourcePaths: ['C:\\Temp'],
+          compression: 'zstd',
+          excludePatterns: [],
+          pruneEnabled: false,
+          keepDaily: 7,
+          keepWeekly: 4,
+          keepMonthly: 6,
+          keepYearly: 1,
+          status: 'idle',
+          lastRun: 'Never',
+          scheduleEnabled: true,
+          scheduleType: 'daily',
+          scheduleTime: '14:00',
+          scheduleBackend: 'windows-task-scheduler',
+          scheduleTaskLastSyncedAt: '2026-01-13T12:00:00.000Z',
+        }] as any}
+        isOpen={true}
+        onClose={() => {}}
+        onAddJob={() => {}}
+        onUpdateJob={() => {}}
+        onDeleteJob={() => {}}
+        onRunJob={() => {}}
+      />
+    );
+
+    expect(await screen.findByText('Windows Task Present')).toBeInTheDocument();
+    expect(screen.getByText(/Task synced:/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Job' }));
+    fireEvent.click(screen.getByRole('button', { name: /Schedule/i }));
+
+    expect(await screen.findByText('Current Windows Task Status')).toBeInTheDocument();
+    expect(screen.getByText('Task name: WinBorg-Docs-job-1')).toBeInTheDocument();
   });
 });

--- a/src/components/JobsModal.test.tsx
+++ b/src/components/JobsModal.test.tsx
@@ -92,7 +92,7 @@ describe('JobsModal', () => {
 
     fireEvent.change(screen.getByLabelText('Frequency'), { target: { value: 'hourly' } });
     expect(screen.getByLabelText('Minute')).toBeInTheDocument();
-    expect(screen.getByText(/Runs once per hour at the selected minute/i)).toBeInTheDocument();
+    expect(screen.getByText(/Runs every hour at the selected minute/i)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Frequency'), { target: { value: 'weekly' } });
     expect(screen.getByLabelText('Day')).toBeInTheDocument();

--- a/src/components/JobsModal.tsx
+++ b/src/components/JobsModal.tsx
@@ -6,17 +6,41 @@ import { Folder, Play, Trash2, X, Plus, Clock, Briefcase, Loader2, Settings, Cal
 import { borgService } from '../services/borgService';
 import { useModalFocusTrap } from '../utils/useModalFocus';
 
+type JobMutationHandler = (job: BackupJob) => Promise<boolean | void> | boolean | void;
+type JobDeleteHandler = (jobId: string) => Promise<boolean | void> | boolean | void;
+
 interface JobsModalProps {
   repo: Repository;
   jobs: BackupJob[];
   isOpen: boolean;
     openTo?: 'list' | 'create';
   onClose: () => void;
-  onAddJob: (job: BackupJob) => void;
-    onUpdateJob: (job: BackupJob) => void;
-  onDeleteJob: (jobId: string) => void;
+    onAddJob: JobMutationHandler;
+        onUpdateJob: JobMutationHandler;
+    onDeleteJob: JobDeleteHandler;
   onRunJob: (jobId: string) => void;
 }
+
+const weekdayOptions = [
+    { value: 0, label: 'Sunday' },
+    { value: 1, label: 'Monday' },
+    { value: 2, label: 'Tuesday' },
+    { value: 3, label: 'Wednesday' },
+    { value: 4, label: 'Thursday' },
+    { value: 5, label: 'Friday' },
+    { value: 6, label: 'Saturday' },
+];
+
+const getDefaultScheduleWeekday = () => new Date().getDay();
+const getDefaultScheduleBackend = (): BackupJob['scheduleBackend'] => 'winborg';
+
+type JobScheduleStatus = {
+    success: boolean;
+    exists?: boolean;
+    unsupported?: boolean;
+    taskName?: string;
+    error?: string;
+};
 
 const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'list', onClose, onAddJob, onUpdateJob, onDeleteJob, onRunJob }) => {
         const titleId = useId();
@@ -25,6 +49,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
   const [activeTab, setActiveTab] = useState<'general' | 'schedule' | 'retention'>('general');
     const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
     const [editingJob, setEditingJob] = useState<BackupJob | null>(null);
+    const [jobScheduleStatuses, setJobScheduleStatuses] = useState<Record<string, JobScheduleStatus>>({});
 
     const closeButtonRef = useRef<HTMLButtonElement>(null);
         const dialogRef = useRef<HTMLDivElement>(null);
@@ -120,8 +145,10 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
 
   // Schedule State
   const [scheduleEnabled, setScheduleEnabled] = useState(false);
-  const [scheduleType, setScheduleType] = useState<'daily' | 'hourly' | 'manual'>('daily');
+    const [scheduleType, setScheduleType] = useState<BackupJob['scheduleType']>('daily');
   const [scheduleTime, setScheduleTime] = useState('14:00');
+    const [scheduleWeekday, setScheduleWeekday] = useState(getDefaultScheduleWeekday);
+        const [scheduleBackend, setScheduleBackend] = useState<BackupJob['scheduleBackend']>(getDefaultScheduleBackend);
 
     useModalFocusTrap(isOpen, dialogRef, { initialFocusRef: closeButtonRef });
 
@@ -145,9 +172,33 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
         return () => window.removeEventListener('keydown', onKeyDown);
     }, [isOpen, onClose]);
 
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const windowsSchedulerJobs = jobs.filter((job) => job.repoId === repo.id && job.scheduleBackend === 'windows-task-scheduler');
+        if (windowsSchedulerJobs.length === 0) {
+            setJobScheduleStatuses({});
+            return;
+        }
+
+        let cancelled = false;
+
+        borgService.getJobScheduleStatuses(windowsSchedulerJobs).then((result) => {
+            if (cancelled) return;
+            setJobScheduleStatuses(result?.statuses || {});
+        }).catch(() => {
+            if (cancelled) return;
+            setJobScheduleStatuses({});
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [isOpen, jobs, repo.id]);
+
     if (!isOpen) return null;
 
-    const handleCreate = () => {
+        const handleCreate = async () => {
       if (!jobName || sourcePaths.length === 0 || !archivePrefix) return;
 
       const excludePatterns = excludePatternsText
@@ -177,7 +228,9 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
               keepYearly,
               scheduleEnabled,
               scheduleType,
-              scheduleTime
+              scheduleTime,
+              scheduleWeekday,
+              scheduleBackend
           };
 
       const updatedJob: BackupJob = {
@@ -197,14 +250,17 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
           keepYearly,
           scheduleEnabled,
           scheduleType,
-          scheduleTime
+          scheduleTime,
+          scheduleWeekday,
+          scheduleBackend
       };
 
-      if (editingJob) {
-          onUpdateJob(updatedJob);
-      } else {
-          onAddJob(updatedJob);
-      }
+      const result = editingJob
+          ? await Promise.resolve(onUpdateJob(updatedJob))
+          : await Promise.resolve(onAddJob(updatedJob));
+
+      if (result === false) return;
+
       resetForm();
       setView('list');
   };
@@ -227,6 +283,8 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
       setScheduleEnabled(false);
       setScheduleType('daily');
       setScheduleTime('14:00');
+      setScheduleWeekday(getDefaultScheduleWeekday());
+      setScheduleBackend(getDefaultScheduleBackend());
       setActiveTab('general');
   };
 
@@ -251,8 +309,15 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
       setKeepMonthly(job.keepMonthly ?? 6);
       setKeepYearly(job.keepYearly ?? 1);
       setScheduleEnabled(!!job.scheduleEnabled);
-      setScheduleType(job.scheduleType || 'daily');
+      setScheduleType(job.scheduleType && job.scheduleType !== 'manual' ? job.scheduleType : 'daily');
       setScheduleTime(job.scheduleTime || '14:00');
+      setScheduleWeekday(Number.isInteger(job.scheduleWeekday) ? job.scheduleWeekday as number : getDefaultScheduleWeekday());
+      setScheduleBackend(job.scheduleBackend || getDefaultScheduleBackend());
+  };
+
+  const handleDelete = async (jobId: string) => {
+      const result = await Promise.resolve(onDeleteJob(jobId));
+      if (result === false) return;
   };
 
   const handleSelectFolder = async () => {
@@ -300,6 +365,48 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
   };
 
   const repoJobs = jobs.filter(j => j.repoId === repo.id);
+
+  const getSchedulerBadge = (job: BackupJob) => {
+      if (job.scheduleBackend === 'windows-task-scheduler') {
+          const status = jobScheduleStatuses[job.id];
+          if (!job.scheduleEnabled) {
+              return {
+                  className: 'text-[10px] text-slate-600 bg-slate-50 dark:bg-slate-900/30 dark:text-slate-300 px-1.5 py-0.5 rounded border border-slate-200 dark:border-slate-700',
+                  text: 'Windows Task Inactive',
+              };
+          }
+
+          if (status?.unsupported) {
+              return {
+                  className: 'text-[10px] text-slate-600 bg-slate-50 dark:bg-slate-900/30 dark:text-slate-300 px-1.5 py-0.5 rounded border border-slate-200 dark:border-slate-700',
+                  text: 'Windows Task Unavailable Here',
+              };
+          }
+
+          if (status?.exists === false) {
+              return {
+                  className: 'text-[10px] text-amber-700 bg-amber-50 dark:bg-amber-900/20 dark:text-amber-300 px-1.5 py-0.5 rounded border border-amber-200 dark:border-amber-800/50',
+                  text: 'Windows Task Missing',
+              };
+          }
+
+          return {
+              className: 'text-[10px] text-emerald-700 bg-emerald-50 dark:bg-emerald-900/20 dark:text-emerald-300 px-1.5 py-0.5 rounded border border-emerald-200 dark:border-emerald-800/50',
+              text: 'Windows Task Present',
+          };
+      }
+
+      if (job.scheduleEnabled) {
+          return {
+              className: 'text-[10px] text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-300 px-1.5 py-0.5 rounded border border-blue-200 dark:border-blue-800/50',
+              text: 'WinBorg Scheduler',
+          };
+      }
+
+      return null;
+  };
+
+  const currentEditingScheduleStatus = editingJob ? jobScheduleStatuses[editingJob.id] : null;
 
   return (
         <div
@@ -350,7 +457,10 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                        </div>
                    ) : (
                        <div className="space-y-3">
-                           {repoJobs.map(job => (
+                           {repoJobs.map(job => {
+                               const schedulerBadge = getSchedulerBadge(job);
+
+                               return (
                                <div key={job.id} className="bg-white dark:bg-slate-700/30 border border-gray-200 dark:border-slate-700 rounded-lg p-4 flex items-center justify-between group hover:border-purple-200 dark:hover:border-purple-800 transition-colors shadow-sm">
                                    <div className="min-w-0 flex-1 mr-4">
                                        <div className="flex items-center gap-2 mb-1">
@@ -362,6 +472,9 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                            )}
                                            {job.pruneEnabled && (
                                                <span className="text-[10px] text-orange-600 bg-orange-50 dark:bg-orange-900/20 px-1.5 py-0.5 rounded border border-orange-100 dark:border-orange-800/50">Auto-Prune</span>
+                                           )}
+                                           {schedulerBadge && (
+                                               <span className={schedulerBadge.className}>{schedulerBadge.text}</span>
                                            )}
                                            {!!job.excludePatterns?.length && (
                                                <span className="text-[10px] text-slate-600 bg-slate-50 dark:bg-slate-900/30 dark:text-slate-300 px-1.5 py-0.5 rounded border border-slate-200 dark:border-slate-700">
@@ -405,6 +518,16 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                        <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
                                            <Clock className="w-3 h-3" /> Last run: {job.lastRun === 'Never' ? 'Never' : new Date(job.lastRun).toLocaleString()}
                                        </div>
+                                       {job.scheduleBackend === 'windows-task-scheduler' && job.scheduleTaskLastSyncedAt && (
+                                           <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
+                                               <Calendar className="w-3 h-3" /> Task synced: {new Date(job.scheduleTaskLastSyncedAt).toLocaleString()}
+                                           </div>
+                                       )}
+                                       {job.scheduleBackend === 'windows-task-scheduler' && jobScheduleStatuses[job.id]?.error && (
+                                           <div className="text-xs text-amber-700 dark:text-amber-300">
+                                               Windows Task status could not be queried.
+                                           </div>
+                                       )}
                                    </div>
                                    <div className="flex items-center gap-2">
                                        <button 
@@ -426,7 +549,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                            <Pencil className="w-4 h-4" />
                                        </button>
                                        <button 
-                                            onClick={() => onDeleteJob(job.id)}
+                                            onClick={() => handleDelete(job.id)}
                                             className="p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
                                             title="Delete Job"
                                             aria-label="Delete Job"
@@ -435,7 +558,8 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                        </button>
                                    </div>
                                </div>
-                           ))}
+                               );
+                           })}
                            
                            <div className="pt-4">
                                <Button variant="secondary" onClick={() => setView('create')} className="w-full border-dashed dark:bg-slate-700 dark:text-slate-300 dark:border-slate-600">
@@ -685,6 +809,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                        <input 
                                            type="checkbox" 
                                            className="w-5 h-5 text-blue-600 rounded"
+                                           aria-label="Enable Schedule"
                                            checked={scheduleEnabled}
                                            onChange={(e) => setScheduleEnabled(e.target.checked)}
                                        />
@@ -692,27 +817,92 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                </div>
 
                                <div className={scheduleEnabled ? 'opacity-100' : 'opacity-50 pointer-events-none'}>
+                                   <div className="mb-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900/30 p-3">
+                                       <label className="flex items-start gap-3 cursor-pointer">
+                                           <input
+                                               type="checkbox"
+                                               className="mt-1 h-4 w-4 rounded text-blue-600"
+                                               aria-label="Use Windows Task Scheduler"
+                                               checked={scheduleBackend === 'windows-task-scheduler'}
+                                               onChange={(e) => setScheduleBackend(e.target.checked ? 'windows-task-scheduler' : 'winborg')}
+                                           />
+                                           <div>
+                                               <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">Use Windows Task Scheduler</div>
+                                               <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                                                   Checked: WinBorg creates and maintains a Windows scheduled task for this job. Unchecked: the built-in WinBorg scheduler runs it while the app is active.
+                                               </p>
+                                               <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                                                   Turning the schedule off or deleting the job removes the external Windows task automatically.
+                                               </p>
+                                           </div>
+                                       </label>
+                                   </div>
+                                   {editingJob && scheduleBackend === 'windows-task-scheduler' && (
+                                       <div className="mb-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50/80 dark:bg-slate-900/40 p-3 text-xs text-slate-600 dark:text-slate-300">
+                                           <div className="font-semibold text-slate-700 dark:text-slate-200">Current Windows Task Status</div>
+                                           <div className="mt-1">
+                                               {currentEditingScheduleStatus?.error
+                                                   ? 'Windows Task status could not be queried right now.'
+                                                   : currentEditingScheduleStatus?.unsupported
+                                                   ? 'Windows Task Scheduler status cannot be queried in this environment.'
+                                                   : currentEditingScheduleStatus?.exists === false
+                                                   ? 'Task is currently missing in Windows Task Scheduler.'
+                                                   : 'Task is currently present in Windows Task Scheduler.'}
+                                           </div>
+                                           {currentEditingScheduleStatus?.taskName && (
+                                               <div className="mt-1">Task name: {currentEditingScheduleStatus.taskName}</div>
+                                           )}
+                                           {editingJob.scheduleTaskLastSyncedAt && (
+                                               <div className="mt-1">Last synchronized: {new Date(editingJob.scheduleTaskLastSyncedAt).toLocaleString()}</div>
+                                           )}
+                                       </div>
+                                   )}
                                    <div className="grid grid-cols-2 gap-4">
                                        <div>
                                            <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">Frequency</label>
                                            <select
                                                className="w-full px-3 py-2 bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-md text-sm text-slate-900 dark:text-white"
+                                               aria-label="Frequency"
                                                value={scheduleType}
-                                               onChange={(e) => setScheduleType(e.target.value as any)}
+                                               onChange={(e) => setScheduleType(e.target.value as BackupJob['scheduleType'])}
                                            >
                                                <option value="daily">Daily</option>
                                                <option value="hourly">Hourly</option>
+                                               <option value="weekly">Weekly</option>
                                            </select>
                                        </div>
-                                       {scheduleType === 'daily' && (
+                                       {scheduleType === 'weekly' && (
                                            <div>
-                                               <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">Time</label>
+                                               <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">Day</label>
+                                               <select
+                                                   className="w-full px-3 py-2 bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-md text-sm text-slate-900 dark:text-white"
+                                                   aria-label="Day"
+                                                   value={scheduleWeekday}
+                                                   onChange={(e) => setScheduleWeekday(Number(e.target.value))}
+                                               >
+                                                   {weekdayOptions.map((option) => (
+                                                       <option key={option.value} value={option.value}>{option.label}</option>
+                                                   ))}
+                                               </select>
+                                           </div>
+                                       )}
+                                       {(scheduleType === 'daily' || scheduleType === 'weekly' || scheduleType === 'hourly') && (
+                                           <div>
+                                               <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">
+                                                   {scheduleType === 'hourly' ? 'Minute' : 'Time'}
+                                               </label>
                                                <input 
                                                    type="time" 
                                                    className="w-full px-3 py-2 bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-md text-sm text-slate-900 dark:text-white"
+                                                   aria-label={scheduleType === 'hourly' ? 'Minute' : 'Time'}
                                                    value={scheduleTime}
                                                    onChange={(e) => setScheduleTime(e.target.value)}
                                                />
+                                               {scheduleType === 'hourly' && (
+                                                   <p className="text-[10px] text-slate-400 mt-1">
+                                                       Runs once per hour at the selected minute. Example: 14:30 runs at :30 every hour.
+                                                   </p>
+                                               )}
                                            </div>
                                        )}
                                    </div>

--- a/src/components/JobsModal.tsx
+++ b/src/components/JobsModal.tsx
@@ -147,6 +147,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
   const [scheduleEnabled, setScheduleEnabled] = useState(false);
     const [scheduleType, setScheduleType] = useState<BackupJob['scheduleType']>('daily');
   const [scheduleTime, setScheduleTime] = useState('14:00');
+  const [scheduleHourInterval, setScheduleHourInterval] = useState(1);
     const [scheduleWeekday, setScheduleWeekday] = useState(getDefaultScheduleWeekday);
         const [scheduleBackend, setScheduleBackend] = useState<BackupJob['scheduleBackend']>(getDefaultScheduleBackend);
 
@@ -229,6 +230,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
               scheduleEnabled,
               scheduleType,
               scheduleTime,
+              scheduleHourInterval: scheduleType === 'hourly' ? scheduleHourInterval : undefined,
               scheduleWeekday,
               scheduleBackend
           };
@@ -251,6 +253,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
           scheduleEnabled,
           scheduleType,
           scheduleTime,
+          scheduleHourInterval: scheduleType === 'hourly' ? scheduleHourInterval : undefined,
           scheduleWeekday,
           scheduleBackend
       };
@@ -311,6 +314,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
       setScheduleEnabled(!!job.scheduleEnabled);
       setScheduleType(job.scheduleType && job.scheduleType !== 'manual' ? job.scheduleType : 'daily');
       setScheduleTime(job.scheduleTime || '14:00');
+      setScheduleHourInterval(Number.isInteger(job.scheduleHourInterval) && job.scheduleHourInterval! > 1 ? job.scheduleHourInterval! : 1);
       setScheduleWeekday(Number.isInteger(job.scheduleWeekday) ? job.scheduleWeekday as number : getDefaultScheduleWeekday());
       setScheduleBackend(job.scheduleBackend || getDefaultScheduleBackend());
   };
@@ -871,6 +875,25 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                                <option value="weekly">Weekly</option>
                                            </select>
                                        </div>
+                                       {scheduleType === 'hourly' && (
+                                           <div>
+                                               <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">Every</label>
+                                               <select
+                                                   className="w-full px-3 py-2 bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-md text-sm text-slate-900 dark:text-white"
+                                                   aria-label="Hour interval"
+                                                   value={scheduleHourInterval}
+                                                   onChange={(e) => setScheduleHourInterval(Number(e.target.value))}
+                                               >
+                                                   <option value={1}>1 hour</option>
+                                                   <option value={2}>2 hours</option>
+                                                   <option value={3}>3 hours</option>
+                                                   <option value={4}>4 hours</option>
+                                                   <option value={6}>6 hours</option>
+                                                   <option value={8}>8 hours</option>
+                                                   <option value={12}>12 hours</option>
+                                               </select>
+                                           </div>
+                                       )}
                                        {scheduleType === 'weekly' && (
                                            <div>
                                                <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">Day</label>
@@ -891,8 +914,8 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                                <label className="block text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase mb-1.5">
                                                    {scheduleType === 'hourly' ? 'Minute' : 'Time'}
                                                </label>
-                                               <input 
-                                                   type="time" 
+                                               <input
+                                                   type="time"
                                                    className="w-full px-3 py-2 bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 rounded-md text-sm text-slate-900 dark:text-white"
                                                    aria-label={scheduleType === 'hourly' ? 'Minute' : 'Time'}
                                                    value={scheduleTime}
@@ -900,7 +923,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                                />
                                                {scheduleType === 'hourly' && (
                                                    <p className="text-[10px] text-slate-400 mt-1">
-                                                       Runs once per hour at the selected minute. Example: 14:30 runs at :30 every hour.
+                                                       Runs every {scheduleHourInterval === 1 ? 'hour' : `${scheduleHourInterval} hours`} at the selected minute. Slots are anchored to midnight.
                                                    </p>
                                                )}
                                            </div>

--- a/src/services/borgService.test.ts
+++ b/src/services/borgService.test.ts
@@ -94,6 +94,27 @@ describe('borgService', () => {
              expect(result).toBe(true);
              expect(mockInvoke).toHaveBeenCalledWith('has-secret', { repoId: 'repo1' });
         });
+
+        it('syncJobSchedules calls ipcRenderer.invoke with previous and next jobs', async () => {
+            mockInvoke.mockResolvedValue({ success: true });
+            const previousJobs = [{ id: 'job-1', scheduleEnabled: false }];
+            const nextJobs = [{ id: 'job-1', scheduleEnabled: true, scheduleBackend: 'windows-task-scheduler' }];
+
+            const result = await borgService.syncJobSchedules(previousJobs as any, nextJobs as any);
+
+            expect(mockInvoke).toHaveBeenCalledWith('sync-job-schedules', { previousJobs, nextJobs });
+            expect(result).toEqual({ success: true });
+        });
+
+        it('getJobScheduleStatuses calls ipcRenderer.invoke with jobs', async () => {
+            mockInvoke.mockResolvedValue({ success: true, statuses: { 'job-1': { success: true, exists: true } } });
+            const jobs = [{ id: 'job-1', scheduleEnabled: true, scheduleBackend: 'windows-task-scheduler' }];
+
+            const result = await borgService.getJobScheduleStatuses(jobs as any);
+
+            expect(mockInvoke).toHaveBeenCalledWith('get-job-schedule-statuses', { jobs });
+            expect(result).toEqual({ success: true, statuses: { 'job-1': { success: true, exists: true } } });
+        });
     });
 
     describe('runCommand', () => {

--- a/src/services/borgService.ts
+++ b/src/services/borgService.ts
@@ -3,7 +3,7 @@
 // This service communicates with the Electron Main process
 
 import { formatBytes, formatDuration } from '../utils/formatters';
-import { ArchiveStats } from '../types';
+import { ArchiveStats, BackupJob } from '../types';
 import { getIpcRendererOrNull, type IpcRendererLike } from './electron';
 
 const fallbackIpcRenderer: IpcRendererLike = {
@@ -166,6 +166,14 @@ export const borgService = {
   hasPassphrase: async (repoId: string): Promise<boolean> => {
       const res = await getIpc().invoke('has-secret', { repoId });
       return res.hasSecret;
+  },
+
+  syncJobSchedules: async (previousJobs: BackupJob[], nextJobs: BackupJob[]): Promise<{ success: boolean; error?: string; details?: any[] }> => {
+      return await getIpc().invoke('sync-job-schedules', { previousJobs, nextJobs });
+  },
+
+  getJobScheduleStatuses: async (jobs: BackupJob[]): Promise<{ success: boolean; statuses?: Record<string, any>; error?: string }> => {
+      return await getIpc().invoke('get-job-schedule-statuses', { jobs });
   },
 
   // --- COMMANDS ---

--- a/src/test/e2eMockContract.test.ts
+++ b/src/test/e2eMockContract.test.ts
@@ -11,6 +11,8 @@ describe('E2E mock IPC contract', () => {
     // smoke flows rely on these being mockable
     'get-db',
     'save-db',
+    'sync-job-schedules',
+    'get-job-schedule-statuses',
     'system-check-wsl',
     'system-check-borg',
     'ssh-test-connection',

--- a/src/test/ipcContract.test.ts
+++ b/src/test/ipcContract.test.ts
@@ -58,6 +58,8 @@ describe('IPC contract (renderer <-> main)', () => {
     'get-app-version',
     'get-db',
     'save-db',
+    'sync-job-schedules',
+    'get-job-schedule-statuses',
     'export-app-data',
     'import-app-data',
 
@@ -103,6 +105,8 @@ describe('IPC contract (renderer <-> main)', () => {
       'save-secret',
       'delete-secret',
       'has-secret',
+      'sync-job-schedules',
+      'get-job-schedule-statuses',
     ];
 
     for (const channel of rendererChannels) {

--- a/src/test/ipcPayloadShapes.test.ts
+++ b/src/test/ipcPayloadShapes.test.ts
@@ -134,6 +134,44 @@ describe('IPC payload shapes (renderer <-> main)', () => {
     ).toBe(true);
   });
 
+  it('sync-job-schedules handler destructures previousJobs/nextJobs and borgService passes matching payload keys', () => {
+    const mainText = fs.readFileSync(electronMainPath, 'utf8');
+    const rendererText = fs.readFileSync(borgServicePath, 'utf8');
+
+    expect(
+      /ipcMain\.handle\(\s*['"]sync-job-schedules['"]\s*,\s*async\s*\(\s*event\s*,\s*\{[^}]*\bpreviousJobs\b[^}]*\bnextJobs\b[^}]*\}\s*\)\s*=>/m.test(
+        mainText
+      ),
+      'Expected sync-job-schedules handler to destructure previousJobs/nextJobs'
+    ).toBe(true);
+
+    expect(
+      /(?:ipcRenderer|getIpc\(\))\.invoke\(\s*['"]sync-job-schedules['"]\s*,\s*\{[\s\S]*?\bpreviousJobs\b[\s\S]*?\bnextJobs\b[\s\S]*?\}\s*\)/m.test(
+        rendererText
+      ),
+      'Expected borgService.syncJobSchedules to invoke sync-job-schedules with previousJobs/nextJobs'
+    ).toBe(true);
+  });
+
+  it('get-job-schedule-statuses handler destructures jobs and borgService passes matching payload key', () => {
+    const mainText = fs.readFileSync(electronMainPath, 'utf8');
+    const rendererText = fs.readFileSync(borgServicePath, 'utf8');
+
+    expect(
+      /ipcMain\.handle\(\s*['"]get-job-schedule-statuses['"]\s*,\s*async\s*\(\s*event\s*,\s*\{[^}]*\bjobs\b[^}]*\}\s*\)\s*=>/m.test(
+        mainText
+      ),
+      'Expected get-job-schedule-statuses handler to destructure jobs'
+    ).toBe(true);
+
+    expect(
+      /(?:ipcRenderer|getIpc\(\))\.invoke\(\s*['"]get-job-schedule-statuses['"]\s*,\s*\{[\s\S]*?\bjobs\b[\s\S]*?\}\s*\)/m.test(
+        rendererText
+      ),
+      'Expected borgService.getJobScheduleStatuses to invoke get-job-schedule-statuses with jobs'
+    ).toBe(true);
+  });
+
   it('SSH handlers destructure expected keys and borgService passes matching payload keys', () => {
     const mainText = fs.readFileSync(electronMainPath, 'utf8');
     const rendererText = fs.readFileSync(borgServicePath, 'utf8');

--- a/src/test/launchArgs.test.ts
+++ b/src/test/launchArgs.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getArgValue, getScheduledJobIdFromArgv } = require('../../main/launchArgs');
+
+describe('main/launchArgs', () => {
+  test('reads separated CLI flag values', () => {
+    expect(getArgValue(['electron', '.', '--run-scheduled-job', 'job-123'], '--run-scheduled-job')).toBe('job-123');
+  });
+
+  test('reads inline CLI flag values', () => {
+    expect(getArgValue(['electron', '.', '--run-scheduled-job=job-123'], '--run-scheduled-job')).toBe('job-123');
+  });
+
+  test('returns null for missing scheduled job id', () => {
+    expect(getScheduledJobIdFromArgv(['electron', '.', '--hidden'])).toBeNull();
+  });
+});

--- a/src/test/scheduler.test.ts
+++ b/src/test/scheduler.test.ts
@@ -66,21 +66,79 @@ describe('main/scheduler', () => {
     expect(res.shouldTrigger).toBe(false);
   });
 
-  test('hourly job triggers only at minute 00 and dedupes by triggerKey', () => {
-    const job = { id: 'j2', scheduleEnabled: true, scheduleType: 'hourly' };
-    const now = new Date();
-    now.setMinutes(0, 0, 0);
+  test('hourly job triggers only at the configured minute and dedupes by triggerKey', () => {
+    const job = { id: 'j2', scheduleEnabled: true, scheduleType: 'hourly', scheduleTime: '14:15' };
+    const now = new Date('2026-01-13T12:15:00');
 
     const first = shouldTriggerScheduledJob(job, now, undefined, { allowCatchUp: false });
     expect(first.shouldTrigger).toBe(true);
+    expect(first.triggerKey).toBe(getTriggerKey(now, 'hourly'));
 
     const second = shouldTriggerScheduledJob(job, now, first.triggerKey, { allowCatchUp: false });
     expect(second.shouldTrigger).toBe(false);
 
     const notTopOfHour = new Date(now);
-    notTopOfHour.setMinutes(1, 0, 0);
+    notTopOfHour.setMinutes(16, 0, 0);
     const third = shouldTriggerScheduledJob(job, notTopOfHour, null, { allowCatchUp: false });
     expect(third.shouldTrigger).toBe(false);
+  });
+
+  test('hourly job catches up once for the configured minute after startup', () => {
+    const job = {
+      id: 'j2-catchup',
+      scheduleEnabled: true,
+      scheduleType: 'hourly',
+      scheduleTime: '09:20',
+      lastRun: 'Never'
+    };
+    const now = new Date('2026-01-13T11:25:00');
+
+    const res = shouldTriggerScheduledJob(job, now, null, {
+      lastRunAt: job.lastRun,
+      allowCatchUp: true
+    });
+
+    expect(res.shouldTrigger).toBe(true);
+    expect(res.mode).toBe('catch-up');
+    expect(res.triggerKey).toBe(getTriggerKey(new Date('2026-01-13T11:20:00'), 'hourly'));
+  });
+
+  test('weekly job triggers on the configured weekday and time and dedupes by triggerKey', () => {
+    const now = new Date('2026-01-12T09:15:00');
+    const job = {
+      id: 'j-weekly',
+      scheduleEnabled: true,
+      scheduleType: 'weekly',
+      scheduleTime: '09:15',
+      scheduleWeekday: now.getDay()
+    };
+
+    const first = shouldTriggerScheduledJob(job, now, null, { allowCatchUp: false });
+    expect(first.shouldTrigger).toBe(true);
+    expect(first.triggerKey).toBe(getTriggerKey(now, 'weekly'));
+
+    const second = shouldTriggerScheduledJob(job, now, first.triggerKey, { allowCatchUp: false });
+    expect(second.shouldTrigger).toBe(false);
+  });
+
+  test('weekly job catches up once after startup when the scheduled minute was missed', () => {
+    const now = new Date('2026-01-12T09:20:00');
+    const job = {
+      id: 'j-weekly-catchup',
+      scheduleEnabled: true,
+      scheduleType: 'weekly',
+      scheduleTime: '09:15',
+      scheduleWeekday: now.getDay(),
+      lastRun: 'Never'
+    };
+
+    const res = shouldTriggerScheduledJob(job, now, null, {
+      lastRunAt: job.lastRun,
+      allowCatchUp: true
+    });
+    expect(res.shouldTrigger).toBe(true);
+    expect(res.mode).toBe('catch-up');
+    expect(res.triggerKey).toBe(getTriggerKey(new Date('2026-01-12T09:15:00'), 'weekly'));
   });
 
   test('tryStartJob prevents parallel runs and finishJob releases', () => {
@@ -100,8 +158,23 @@ describe('main/scheduler', () => {
     expect(shouldTriggerScheduledJob(disabled, now, null).shouldTrigger).toBe(false);
   });
 
+  test('does not trigger jobs managed by Windows Task Scheduler', () => {
+    const now = new Date('2026-01-13T12:15:00');
+    const job = {
+      id: 'j-windows-task',
+      scheduleEnabled: true,
+      scheduleBackend: 'windows-task-scheduler',
+      scheduleType: 'daily',
+      scheduleTime: '12:15'
+    };
+
+    const res = shouldTriggerScheduledJob(job, now, null);
+    expect(res.shouldTrigger).toBe(false);
+    expect(res.triggerKey).toBe(null);
+  });
+
   test('does not trigger for unknown scheduleType', () => {
-    const job = { id: 'j4', scheduleEnabled: true, scheduleType: 'weekly', scheduleTime: '12:34' };
+    const job = { id: 'j4', scheduleEnabled: true, scheduleType: 'monthly', scheduleTime: '12:34' };
     const now = new Date();
     now.setHours(12, 34, 0, 0);
 

--- a/src/test/scheduler.test.ts
+++ b/src/test/scheduler.test.ts
@@ -103,6 +103,75 @@ describe('main/scheduler', () => {
     expect(res.triggerKey).toBe(getTriggerKey(new Date('2026-01-13T11:20:00'), 'hourly'));
   });
 
+  test('every-4-hours job triggers at correct interval slots anchored to midnight', () => {
+    const job = {
+      id: 'j-4h',
+      scheduleEnabled: true,
+      scheduleType: 'hourly',
+      scheduleHourInterval: 4,
+      scheduleTime: '00:00',
+    };
+
+    // At exactly 08:00 → slot 08:00 should trigger
+    const atSlot = new Date('2026-01-13T08:00:00');
+    const first = shouldTriggerScheduledJob(job, atSlot, null, { allowCatchUp: false });
+    expect(first.shouldTrigger).toBe(true);
+    expect(first.triggerKey).toBe(getTriggerKey(atSlot, 'hourly'));
+
+    // At 09:30 → slot is still 08:00, already triggered, should not re-trigger
+    const between = new Date('2026-01-13T09:30:00');
+    const second = shouldTriggerScheduledJob(job, between, first.triggerKey, { allowCatchUp: false });
+    expect(second.shouldTrigger).toBe(false);
+
+    // At 12:00 → new slot, should trigger again
+    const nextSlot = new Date('2026-01-13T12:00:00');
+    const third = shouldTriggerScheduledJob(job, nextSlot, first.triggerKey, { allowCatchUp: false });
+    expect(third.shouldTrigger).toBe(true);
+    expect(third.triggerKey).toBe(getTriggerKey(nextSlot, 'hourly'));
+  });
+
+  test('every-4-hours job with minute offset triggers at correct slot time', () => {
+    const job = {
+      id: 'j-4h-offset',
+      scheduleEnabled: true,
+      scheduleType: 'hourly',
+      scheduleHourInterval: 4,
+      scheduleTime: '00:15', // run at :15 within each slot
+    };
+
+    // At 08:15 → slot 08:15 should trigger
+    const atSlot = new Date('2026-01-13T08:15:00');
+    const res = shouldTriggerScheduledJob(job, atSlot, null, { allowCatchUp: false });
+    expect(res.shouldTrigger).toBe(true);
+
+    // At 08:10 → slot is 04:15, not yet at 08:15
+    const before = new Date('2026-01-13T08:10:00');
+    const res2 = shouldTriggerScheduledJob(job, before, null, { allowCatchUp: false });
+    expect(res2.shouldTrigger).toBe(false);
+  });
+
+  test('every-4-hours job catches up when startup missed a slot', () => {
+    const job = {
+      id: 'j-4h-catchup',
+      scheduleEnabled: true,
+      scheduleType: 'hourly',
+      scheduleHourInterval: 4,
+      scheduleTime: '00:00',
+      lastRun: 'Never',
+    };
+
+    // App started at 09:05, slot 08:00 was missed
+    const now = new Date('2026-01-13T09:05:00');
+    const res = shouldTriggerScheduledJob(job, now, null, {
+      lastRunAt: job.lastRun,
+      allowCatchUp: true,
+    });
+
+    expect(res.shouldTrigger).toBe(true);
+    expect(res.mode).toBe('catch-up');
+    expect(res.triggerKey).toBe(getTriggerKey(new Date('2026-01-13T08:00:00'), 'hourly'));
+  });
+
   test('weekly job triggers on the configured weekday and time and dedupes by triggerKey', () => {
     const now = new Date('2026-01-12T09:15:00');
     const job = {

--- a/src/test/windowsTaskScheduler.test.ts
+++ b/src/test/windowsTaskScheduler.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment node
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  WINBORG_SCHEDULER_BACKEND,
+  WINDOWS_TASK_SCHEDULER_BACKEND,
+  buildQueryTaskArgs,
+  buildCreateTaskArgs,
+  createWindowsTaskScheduler,
+  getScheduleBackend,
+  getTaskNameForJob,
+  shouldTrackWindowsTask,
+  shouldUseWindowsTaskScheduler,
+} = require('../../main/windowsTaskScheduler');
+
+describe('main/windowsTaskScheduler', () => {
+  const launchContext = {
+    executablePath: 'C:\\Program Files\\WinBorg\\WinBorg.exe',
+    appPathArg: null,
+  };
+
+  test('defaults to the internal WinBorg scheduler backend', () => {
+    expect(getScheduleBackend({ scheduleEnabled: true })).toBe(WINBORG_SCHEDULER_BACKEND);
+    expect(shouldUseWindowsTaskScheduler({ scheduleEnabled: true })).toBe(false);
+    expect(shouldTrackWindowsTask({ scheduleEnabled: true })).toBe(false);
+  });
+
+  test('builds query args for a Windows scheduled task', () => {
+    const job = {
+      id: 'job-query',
+      name: 'Query Backup',
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+    };
+
+    expect(buildQueryTaskArgs(job)).toEqual(['/Query', '/TN', getTaskNameForJob(job)]);
+    expect(shouldTrackWindowsTask(job)).toBe(true);
+  });
+
+  test('builds a daily scheduled task command', () => {
+    const job = {
+      id: 'job-1',
+      name: 'Daily Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'daily',
+      scheduleTime: '14:30',
+    };
+
+    const args = buildCreateTaskArgs(job, launchContext);
+    expect(args).toEqual(expect.arrayContaining(['/SC', 'DAILY', '/ST', '14:30']));
+    expect(args).toEqual(expect.arrayContaining(['/TN', getTaskNameForJob(job)]));
+    expect(args).toEqual(expect.arrayContaining(['/TR', expect.stringContaining('--run-scheduled-job')]));
+  });
+
+  test('builds an hourly scheduled task with the configured minute', () => {
+    const job = {
+      id: 'job-2',
+      name: 'Hourly Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'hourly',
+      scheduleTime: '09:15',
+    };
+
+    const args = buildCreateTaskArgs(job, launchContext);
+    expect(args).toEqual(expect.arrayContaining(['/SC', 'HOURLY', '/MO', '1', '/ST', '00:15']));
+  });
+
+  test('builds a weekly scheduled task with the configured weekday', () => {
+    const job = {
+      id: 'job-3',
+      name: 'Weekly Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'weekly',
+      scheduleTime: '08:45',
+      scheduleWeekday: 1,
+    };
+
+    const args = buildCreateTaskArgs(job, launchContext);
+    expect(args).toEqual(expect.arrayContaining(['/SC', 'WEEKLY', '/D', 'MON', '/ST', '08:45']));
+  });
+
+  test('syncJobs fails on non-Windows when external tasks are requested', async () => {
+    const scheduler = createWindowsTaskScheduler({
+      spawnCapture: vi.fn(),
+      platform: 'linux',
+      logger: { warn: vi.fn() },
+    });
+
+    const result = await scheduler.syncJobs([], [{
+      id: 'job-4',
+      name: 'External Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'daily',
+      scheduleTime: '10:00',
+    }], launchContext);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('only available on Windows');
+  });
+
+  test('syncJobs deletes renamed tasks and upserts current external jobs', async () => {
+    const spawnCapture = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '', error: null });
+    const scheduler = createWindowsTaskScheduler({
+      spawnCapture,
+      platform: 'win32',
+      logger: { warn: vi.fn() },
+    });
+
+    const previousJobs = [{
+      id: 'job-5',
+      name: 'Old Name',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'daily',
+      scheduleTime: '06:00',
+    }];
+
+    const nextJobs = [{
+      id: 'job-5',
+      name: 'New Name',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'daily',
+      scheduleTime: '06:00',
+    }];
+
+    const result = await scheduler.syncJobs(previousJobs, nextJobs, launchContext);
+
+    expect(result.success).toBe(true);
+    expect(spawnCapture).toHaveBeenNthCalledWith(
+      1,
+      'schtasks.exe',
+      expect.arrayContaining(['/Delete', '/TN', getTaskNameForJob(previousJobs[0]), '/F']),
+      expect.any(Object)
+    );
+    expect(spawnCapture).toHaveBeenNthCalledWith(
+      2,
+      'schtasks.exe',
+      expect.arrayContaining(['/Create', '/TN', getTaskNameForJob(nextJobs[0]), '/F']),
+      expect.any(Object)
+    );
+  });
+
+  test('getJobStatuses reports whether tracked tasks exist', async () => {
+    const spawnCapture = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 0, stdout: 'task exists', stderr: '', error: null })
+      .mockResolvedValueOnce({ code: 1, stdout: '', stderr: 'ERROR: The system cannot find the file specified.', error: null });
+
+    const scheduler = createWindowsTaskScheduler({
+      spawnCapture,
+      platform: 'win32',
+      logger: { warn: vi.fn() },
+    });
+
+    const jobs = [
+      {
+        id: 'job-6',
+        name: 'Present Task',
+        scheduleEnabled: true,
+        scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+        scheduleType: 'daily',
+        scheduleTime: '06:00',
+      },
+      {
+        id: 'job-7',
+        name: 'Missing Task',
+        scheduleEnabled: true,
+        scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+        scheduleType: 'daily',
+        scheduleTime: '06:00',
+      },
+    ];
+
+    const result = await scheduler.getJobStatuses(jobs);
+
+    expect(result.success).toBe(true);
+    expect(result.statuses['job-6']).toEqual(expect.objectContaining({ success: true, exists: true }));
+    expect(result.statuses['job-7']).toEqual(expect.objectContaining({ success: true, exists: false }));
+  });
+});

--- a/src/test/windowsTaskScheduler.test.ts
+++ b/src/test/windowsTaskScheduler.test.ts
@@ -9,6 +9,7 @@ const {
   createWindowsTaskScheduler,
   getScheduleBackend,
   getTaskNameForJob,
+  quoteWindowsCommandArg,
   shouldTrackWindowsTask,
   shouldUseWindowsTaskScheduler,
 } = require('../../main/windowsTaskScheduler');
@@ -34,6 +35,12 @@ describe('main/windowsTaskScheduler', () => {
 
     expect(buildQueryTaskArgs(job)).toEqual(['/Query', '/TN', getTaskNameForJob(job)]);
     expect(shouldTrackWindowsTask(job)).toBe(true);
+  });
+
+  test('quotes Windows command arguments with backslashes and quotes safely', () => {
+    const quoted = quoteWindowsCommandArg('C:\\Program Files\\WinBorg\\"quoted"\\');
+
+    expect(quoted).toBe('"C:\\Program Files\\WinBorg\\\\\\"quoted\\"\\\\"');
   });
 
   test('builds a daily scheduled task command', () => {

--- a/src/test/windowsTaskScheduler.test.ts
+++ b/src/test/windowsTaskScheduler.test.ts
@@ -73,6 +73,21 @@ describe('main/windowsTaskScheduler', () => {
     expect(args).toEqual(expect.arrayContaining(['/SC', 'HOURLY', '/MO', '1', '/ST', '00:15']));
   });
 
+  test('builds an every-4-hours scheduled task with the correct /MO modifier', () => {
+    const job = {
+      id: 'job-4h',
+      name: '4-Hour Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'hourly',
+      scheduleTime: '00:30',
+      scheduleHourInterval: 4,
+    };
+
+    const args = buildCreateTaskArgs(job, launchContext);
+    expect(args).toEqual(expect.arrayContaining(['/SC', 'HOURLY', '/MO', '4', '/ST', '00:30']));
+  });
+
   test('builds a weekly scheduled task with the configured weekday', () => {
     const job = {
       id: 'job-3',

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,8 +114,11 @@ export interface BackupJob {
 
     // Schedule (Metadata for future background service)
     scheduleEnabled: boolean;
-    scheduleType: 'daily' | 'hourly' | 'manual';
+    scheduleType: 'daily' | 'hourly' | 'weekly' | 'manual';
     scheduleTime: string; // "14:00"
+    scheduleWeekday?: number; // 0 = Sunday, 6 = Saturday
+    scheduleBackend?: 'winborg' | 'windows-task-scheduler';
+    scheduleTaskLastSyncedAt?: string;
 }
 
 export interface Archive {

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,7 @@ export interface BackupJob {
     scheduleEnabled: boolean;
     scheduleType: 'daily' | 'hourly' | 'weekly' | 'manual';
     scheduleTime: string; // "14:00"
+    scheduleHourInterval?: number; // for hourly: run every N hours (1, 2, 3, 4, 6, 8, 12)
     scheduleWeekday?: number; // 0 = Sunday, 6 = Saturday
     scheduleBackend?: 'winborg' | 'windows-task-scheduler';
     scheduleTaskLastSyncedAt?: string;

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,4 +1,5 @@
 
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { formatBytes, formatDuration, parseSizeString, formatDate, getNextRunForRepo } from './formatters';
 import { BackupJob } from '../types';
 
@@ -19,10 +20,20 @@ const createMockJob = (overrides: Partial<BackupJob>): BackupJob => ({
     scheduleEnabled: false,
     scheduleType: 'manual',
     scheduleTime: '00:00',
+    scheduleWeekday: 1,
     ...overrides
 });
 
 describe('formatters', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-13T12:10:00'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     describe('parseSizeString', () => {
         it('parses valid strings correctly', () => {
             expect(parseSizeString('100 B')).toBe(100);
@@ -99,16 +110,25 @@ describe('formatters', () => {
 
         it('calculates hourly schedule', () => {
              const jobs: BackupJob[] = [
-                createMockJob({ id: '1', repoId: repoId, scheduleEnabled: true, scheduleType: 'hourly' })
+                     createMockJob({ id: '1', repoId: repoId, scheduleEnabled: true, scheduleType: 'hourly', scheduleTime: '00:45' })
+             ];
+             const result = getNextRunForRepo(jobs, repoId);
+             expect(result).not.toBeNull();
+                 expect(result).toContain('12:45');
+        });
+
+        it('calculates daily schedule', () => {
+            const jobs: BackupJob[] = [
+                createMockJob({ id: '1', repoId: repoId, scheduleEnabled: true, scheduleType: 'daily', scheduleTime: '12:00' })
              ];
              const result = getNextRunForRepo(jobs, repoId);
              expect(result).not.toBeNull();
              expect(typeof result).toBe('string');
         });
 
-        it('calculates daily schedule', () => {
+        it('calculates weekly schedule', () => {
             const jobs: BackupJob[] = [
-                createMockJob({ id: '1', repoId: repoId, scheduleEnabled: true, scheduleType: 'daily', scheduleTime: '12:00' })
+                createMockJob({ id: '1', repoId: repoId, scheduleEnabled: true, scheduleType: 'weekly', scheduleTime: '12:00', scheduleWeekday: 2 })
              ];
              const result = getNextRunForRepo(jobs, repoId);
              expect(result).not.toBeNull();

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,6 +1,20 @@
 
 import { BackupJob } from '../types';
 
+const resolveScheduleWeekday = (job: BackupJob, fallbackDate: Date): number => {
+    if (Number.isInteger(job.scheduleWeekday) && job.scheduleWeekday! >= 0 && job.scheduleWeekday! <= 6) {
+        return job.scheduleWeekday!;
+    }
+
+    return fallbackDate.getDay();
+};
+
+const resolveScheduleTime = (job: BackupJob, fallback = '00:00'): string => {
+    return typeof job.scheduleTime === 'string' && /^\d{2}:\d{2}$/.test(job.scheduleTime)
+        ? job.scheduleTime
+        : fallback;
+};
+
 export const parseSizeString = (sizeStr: string): number => {
   if (!sizeStr || sizeStr === 'Unknown') return 0;
   const units = {
@@ -68,13 +82,27 @@ export const getNextRunForRepo = (jobs: BackupJob[], repoId: string): string | n
         let nextDate = new Date();
         
         if (job.scheduleType === 'hourly') {
-            // Next top of the hour
-            nextDate.setHours(now.getHours() + 1, 0, 0, 0);
+            const [, m] = resolveScheduleTime(job).split(':').map(Number);
+            nextDate.setSeconds(0, 0);
+            nextDate.setMinutes(m, 0, 0);
+            if (nextDate <= now) {
+                nextDate.setHours(nextDate.getHours() + 1);
+            }
         } else if (job.scheduleType === 'daily' && job.scheduleTime) {
-            const [h, m] = job.scheduleTime.split(':').map(Number);
+            const [h, m] = resolveScheduleTime(job, '14:00').split(':').map(Number);
             nextDate.setHours(h, m, 0, 0);
             if (nextDate <= now) {
                 nextDate.setDate(now.getDate() + 1); // Tomorrow
+            }
+        } else if (job.scheduleType === 'weekly' && job.scheduleTime) {
+            const [h, m] = resolveScheduleTime(job, '14:00').split(':').map(Number);
+            const weekday = resolveScheduleWeekday(job, now);
+            const daysUntilNextRun = (weekday - now.getDay() + 7) % 7;
+
+            nextDate.setHours(h, m, 0, 0);
+            nextDate.setDate(now.getDate() + daysUntilNextRun);
+            if (nextDate <= now) {
+                nextDate.setDate(nextDate.getDate() + 7);
             }
         } else {
             return;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -83,10 +83,14 @@ export const getNextRunForRepo = (jobs: BackupJob[], repoId: string): string | n
         
         if (job.scheduleType === 'hourly') {
             const [, m] = resolveScheduleTime(job).split(':').map(Number);
-            nextDate.setSeconds(0, 0);
-            nextDate.setMinutes(m, 0, 0);
+            const interval = (Number.isInteger(job.scheduleHourInterval) && job.scheduleHourInterval! > 1)
+                ? job.scheduleHourInterval!
+                : 1;
+            const currentHour = now.getHours();
+            const slotHour = Math.floor(currentHour / interval) * interval;
+            nextDate.setHours(slotHour, m, 0, 0);
             if (nextDate <= now) {
-                nextDate.setHours(nextDate.getHours() + 1);
+                nextDate.setHours(slotHour + interval, m, 0, 0);
             }
         } else if (job.scheduleType === 'daily' && job.scheduleTime) {
             const [h, m] = resolveScheduleTime(job, '14:00').split(':').map(Number);


### PR DESCRIPTION
Closes #182

## Summary

- Adds an **"Every N hours"** dropdown to the schedule UI when **Hourly** frequency is selected (options: 1, 2, 3, 4, 6, 8, 12 hours)
- Interval slots are anchored to midnight — e.g. "every 4 hours" always fires at 00:xx, 04:xx, 08:xx, 12:xx, 16:xx, 20:xx
- The existing minute picker continues to set the minute-offset within each slot
- Windows Task Scheduler uses the \`/MO\` modifier (\`/SC HOURLY /MO 4\`) to match the configured interval
- Fully backwards compatible — existing jobs without \`scheduleHourInterval\` default to 1 (every hour, unchanged behaviour)

## Changes

| File | What changed |
|------|-------------|
| \`src/types.ts\` | \`scheduleHourInterval?: number\` added to \`BackupJob\` |
| \`main/scheduler.js\` | Hourly slot calculation uses midnight-anchored interval |
| \`src/components/JobsModal.tsx\` | "Every" dropdown + state wiring |
| \`src/utils/formatters.ts\` | Next-run calculation respects interval |
| \`main/windowsTaskScheduler.js\` | \`/MO N\` in \`schtasks\` command |
| \`src/test/scheduler.test.ts\` | 4 new interval tests (trigger, offset, catch-up, dedup) |
| \`src/test/windowsTaskScheduler.test.ts\` | 1 new test for \`/MO 4\` output |

## Test plan

- [x] Create a new job with "Hourly / Every 4 hours / :00" — verify it fires at 00:00, 04:00, 08:00, …
- [x] Edit an existing hourly job — interval dropdown initialises from saved value
- [x] Existing jobs without \`scheduleHourInterval\` still fire every hour (backwards compat)
- [x] Windows Task Scheduler: check \`schtasks /Query\` output shows correct repetition interval
- [x] All 260 unit tests pass
