### PR TITLE
feat: run scheduled task ASAP if start is missed

### DIFF
--- a/main/windowsTaskScheduler.js
+++ b/main/windowsTaskScheduler.js
@@ -106,6 +106,12 @@ function buildCreateTaskArgs(job, launchContext) {
     ];
 }
 
+function buildPatchStartWhenAvailableArgs(taskName) {
+    const escaped = taskName.replace(/'/g, "''");
+    const command = `$task = Get-ScheduledTask -TaskName '${escaped}'; $task.Settings.StartWhenAvailable = $true; $task | Set-ScheduledTask`;
+    return ['-NonInteractive', '-NoProfile', '-Command', command];
+}
+
 function buildDeleteTaskArgs(job) {
     return ['/Delete', '/TN', getTaskNameForJob(job), '/F'];
 }
@@ -150,6 +156,14 @@ function createWindowsTaskScheduler({ spawnCapture, platform = process.platform,
                     error: getTaskSchedulerError(result, `Failed to create scheduled task for ${job.name}.`),
                     taskName: getTaskNameForJob(job),
                 };
+            }
+
+            if (job.scheduleRunIfMissed === true) {
+                const taskName = getTaskNameForJob(job);
+                const patchResult = await spawnCapture('powershell.exe', buildPatchStartWhenAvailableArgs(taskName), { timeoutMs: 30000 });
+                if (patchResult.error || patchResult.code !== 0) {
+                    logger.warn && logger.warn('[TaskScheduler] Failed to set StartWhenAvailable', patchResult);
+                }
             }
 
             return { success: true, taskName: getTaskNameForJob(job) };
@@ -316,6 +330,7 @@ module.exports = {
     buildCreateTaskArgs,
     buildDeleteTaskArgs,
     buildQueryTaskArgs,
+    buildPatchStartWhenAvailableArgs,
     quoteWindowsCommandArg,
     createWindowsTaskScheduler,
     shouldTrackWindowsTask,

--- a/src/components/JobsModal.tsx
+++ b/src/components/JobsModal.tsx
@@ -148,6 +148,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
     const [scheduleType, setScheduleType] = useState<BackupJob['scheduleType']>('daily');
   const [scheduleTime, setScheduleTime] = useState('14:00');
   const [scheduleHourInterval, setScheduleHourInterval] = useState(1);
+  const [scheduleRunIfMissed, setScheduleRunIfMissed] = useState(false);
     const [scheduleWeekday, setScheduleWeekday] = useState(getDefaultScheduleWeekday);
         const [scheduleBackend, setScheduleBackend] = useState<BackupJob['scheduleBackend']>(getDefaultScheduleBackend);
 
@@ -232,7 +233,8 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
               scheduleTime,
               scheduleHourInterval: scheduleType === 'hourly' ? scheduleHourInterval : undefined,
               scheduleWeekday,
-              scheduleBackend
+              scheduleBackend,
+              scheduleRunIfMissed: scheduleBackend === 'windows-task-scheduler' ? scheduleRunIfMissed : undefined,
           };
 
       const updatedJob: BackupJob = {
@@ -255,7 +257,8 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
           scheduleTime,
           scheduleHourInterval: scheduleType === 'hourly' ? scheduleHourInterval : undefined,
           scheduleWeekday,
-          scheduleBackend
+          scheduleBackend,
+          scheduleRunIfMissed: scheduleBackend === 'windows-task-scheduler' ? scheduleRunIfMissed : undefined,
       };
 
       const result = editingJob
@@ -315,6 +318,7 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
       setScheduleType(job.scheduleType && job.scheduleType !== 'manual' ? job.scheduleType : 'daily');
       setScheduleTime(job.scheduleTime || '14:00');
       setScheduleHourInterval(Number.isInteger(job.scheduleHourInterval) && job.scheduleHourInterval! > 1 ? job.scheduleHourInterval! : 1);
+      setScheduleRunIfMissed(job.scheduleRunIfMissed === true);
       setScheduleWeekday(Number.isInteger(job.scheduleWeekday) ? job.scheduleWeekday as number : getDefaultScheduleWeekday());
       setScheduleBackend(job.scheduleBackend || getDefaultScheduleBackend());
   };
@@ -841,6 +845,25 @@ const JobsModal: React.FC<JobsModalProps> = ({ repo, jobs, isOpen, openTo = 'lis
                                            </div>
                                        </label>
                                    </div>
+                                   {scheduleBackend === 'windows-task-scheduler' && (
+                                       <div className="mb-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-white/70 dark:bg-slate-900/30 p-3">
+                                           <label className="flex items-start gap-3 cursor-pointer">
+                                               <input
+                                                   type="checkbox"
+                                                   className="mt-1 h-4 w-4 rounded text-blue-600"
+                                                   aria-label="Run task as soon as possible if a scheduled start is missed"
+                                                   checked={scheduleRunIfMissed}
+                                                   onChange={(e) => setScheduleRunIfMissed(e.target.checked)}
+                                               />
+                                               <div>
+                                                   <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">Run as soon as possible if start is missed</div>
+                                                   <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                                                       If the PC was off during a scheduled backup, Windows will run it immediately once the PC is back on.
+                                                   </p>
+                                               </div>
+                                           </label>
+                                       </div>
+                                   )}
                                    {editingJob && scheduleBackend === 'windows-task-scheduler' && (
                                        <div className="mb-4 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50/80 dark:bg-slate-900/40 p-3 text-xs text-slate-600 dark:text-slate-300">
                                            <div className="font-semibold text-slate-700 dark:text-slate-200">Current Windows Task Status</div>

--- a/src/test/windowsTaskScheduler.test.ts
+++ b/src/test/windowsTaskScheduler.test.ts
@@ -6,6 +6,7 @@ const {
   WINDOWS_TASK_SCHEDULER_BACKEND,
   buildQueryTaskArgs,
   buildCreateTaskArgs,
+  buildPatchStartWhenAvailableArgs,
   createWindowsTaskScheduler,
   getScheduleBackend,
   getTaskNameForJob,
@@ -202,5 +203,62 @@ describe('main/windowsTaskScheduler', () => {
     expect(result.success).toBe(true);
     expect(result.statuses['job-6']).toEqual(expect.objectContaining({ success: true, exists: true }));
     expect(result.statuses['job-7']).toEqual(expect.objectContaining({ success: true, exists: false }));
+  });
+
+  test('buildPatchStartWhenAvailableArgs builds a PowerShell command to set StartWhenAvailable', () => {
+    const args = buildPatchStartWhenAvailableArgs('WinBorg-My-Backup-abc123');
+    expect(args).toEqual(['-NonInteractive', '-NoProfile', '-Command', expect.stringContaining('StartWhenAvailable = $true')]);
+    expect(args[3]).toContain('WinBorg-My-Backup-abc123');
+    expect(args[3]).toContain('Set-ScheduledTask');
+  });
+
+  test('upsertJob calls PowerShell to set StartWhenAvailable when scheduleRunIfMissed is true', async () => {
+    const spawnCapture = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '', error: null });
+    const scheduler = createWindowsTaskScheduler({
+      spawnCapture,
+      platform: 'win32',
+      logger: { warn: vi.fn() },
+    });
+
+    const job = {
+      id: 'job-runmissed',
+      name: 'Catchup Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'daily',
+      scheduleTime: '03:00',
+      scheduleRunIfMissed: true,
+    };
+
+    const result = await scheduler.upsertJob(job, launchContext);
+
+    expect(result.success).toBe(true);
+    expect(spawnCapture).toHaveBeenCalledTimes(2);
+    expect(spawnCapture).toHaveBeenNthCalledWith(1, 'schtasks.exe', expect.arrayContaining(['/Create']), expect.any(Object));
+    expect(spawnCapture).toHaveBeenNthCalledWith(2, 'powershell.exe', expect.arrayContaining(['-Command', expect.stringContaining('StartWhenAvailable')]), expect.any(Object));
+  });
+
+  test('upsertJob does not call PowerShell when scheduleRunIfMissed is false', async () => {
+    const spawnCapture = vi.fn().mockResolvedValue({ code: 0, stdout: 'ok', stderr: '', error: null });
+    const scheduler = createWindowsTaskScheduler({
+      spawnCapture,
+      platform: 'win32',
+      logger: { warn: vi.fn() },
+    });
+
+    const job = {
+      id: 'job-no-runmissed',
+      name: 'Normal Backup',
+      scheduleEnabled: true,
+      scheduleBackend: WINDOWS_TASK_SCHEDULER_BACKEND,
+      scheduleType: 'daily',
+      scheduleTime: '03:00',
+      scheduleRunIfMissed: false,
+    };
+
+    await scheduler.upsertJob(job, launchContext);
+
+    expect(spawnCapture).toHaveBeenCalledTimes(1);
+    expect(spawnCapture).toHaveBeenCalledWith('schtasks.exe', expect.any(Array), expect.any(Object));
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export interface BackupJob {
     scheduleHourInterval?: number; // for hourly: run every N hours (1, 2, 3, 4, 6, 8, 12)
     scheduleWeekday?: number; // 0 = Sunday, 6 = Saturday
     scheduleBackend?: 'winborg' | 'windows-task-scheduler';
+    scheduleRunIfMissed?: boolean; // Windows Task Scheduler: run ASAP if a scheduled start was missed
     scheduleTaskLastSyncedAt?: string;
 }
 


### PR DESCRIPTION
Closes #181

## Summary

- Adds a **"Run as soon as possible if start is missed"** checkbox to the schedule UI, visible when the Windows Task Scheduler backend is selected
- When enabled, WinBorg patches the created task via PowerShell to set `StartWhenAvailable = true` — equivalent to the identically named option in the Windows Task Scheduler GUI
- The PowerShell patch runs after successful `schtasks /Create`; a failure to patch is logged as a warning but does not fail the overall task creation
- Fully backwards compatible — existing jobs without `scheduleRunIfMissed` behave as before

## Changes

| File | What changed |
|------|-------------|
| `src/types.ts` | `scheduleRunIfMissed?: boolean` added to `BackupJob` |
| `main/windowsTaskScheduler.js` | `buildPatchStartWhenAvailableArgs()` + PowerShell call in `upsertJob` |
| `src/components/JobsModal.tsx` | Checkbox in Windows Task Scheduler section + state wiring |
| `src/test/windowsTaskScheduler.test.ts` | 3 new tests (args shape, PowerShell called when true, not called when false) |

## Test plan

- [ ] Create a Windows Task Scheduler job with the new checkbox enabled — verify the task in Windows Task Scheduler UI shows "Run task as soon as possible after a scheduled start is missed" checked
- [ ] Create a job with the checkbox disabled — verify the setting is absent
- [ ] Set the PC clock past a scheduled time without running — turn the option on, reboot, verify the backup runs on startup
- [ ] All 263 unit tests pass