### PR TITLE
feat: show current file being backed up during borg create (closes #203)

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -1659,10 +1659,10 @@ ipcMain.handle('borg-spawn', async (event, { args, commandId, useWsl, executable
             }
             if (useWsl) {
                 bin = 'wsl';
-                
+
                 const linuxCmd = forceBinary || (executablePath === 'borg' ? '/usr/bin/borg' : executablePath) || '/usr/bin/borg';
                 let execArgs = [];
-                
+
                 // Target specific distro if we found one (Ubuntu/Debian) to avoid running in Docker/Default
                 if (detectedDistro) {
                     execArgs.push('-d', detectedDistro);
@@ -1674,6 +1674,34 @@ ipcMain.handle('borg-spawn', async (event, { args, commandId, useWsl, executable
             }
             console.log(`[Spawn] ${bin} ${finalArgs.join(' ')} (ID: ${commandId})`);
             const child = spawn(bin, finalArgs, { env: spawnEnv, cwd: cwd || undefined });
+
+            // Buffer for incomplete stderr lines. Borg --progress uses \r-terminated lines;
+            // we split on both \r and \n so each frame is processed independently.
+            let stderrBuf = '';
+            // Matches a borg create --progress line: SIZE O SIZE SIZE NFILES TYPE PATH
+            // e.g. "  1.20 kB O   1.20 kB   1.20 kB      1 A /home/user/file.txt"
+            const BORG_PROGRESS_RE = /^[\s]*[\d.,]+\s+[A-Za-z]+\s+O\s+[\d.,]+\s+[A-Za-z]+\s+[\d.,]+\s+[A-Za-z]+\s+(\d+)\s+([A-Z?-])\s+(.+)$/;
+
+            const handleStderr = (data) => {
+                const text = data.toString();
+                safeSendToRenderer('terminal-log', { id: commandId, text });
+
+                stderrBuf += text;
+                const segs = stderrBuf.split(/[\r\n]/);
+                stderrBuf = segs.pop() ?? '';
+                for (const seg of segs) {
+                    const m = seg.match(BORG_PROGRESS_RE);
+                    // path '-' means borg has no current file (initialising); skip it
+                    if (m && m[3] && m[3].trim() !== '-') {
+                        safeSendToRenderer('borg-archive-progress', {
+                            id: commandId,
+                            path: m[3].trim(),
+                            nfiles: parseInt(m[1], 10),
+                        });
+                    }
+                }
+            };
+
             registerManagedChild({
                 map: activeProcesses,
                 id: commandId,
@@ -1682,7 +1710,7 @@ ipcMain.handle('borg-spawn', async (event, { args, commandId, useWsl, executable
                 // Stability-first: do not enforce a default timeout here to avoid breaking long backups.
                 // Renderer may implement its own deadline logic and call borg-stop.
                 onStdout: (data) => safeSendToRenderer('terminal-log', { id: commandId, text: data.toString() }),
-                onStderr: (data) => safeSendToRenderer('terminal-log', { id: commandId, text: data.toString() }),
+                onStderr: handleStderr,
                 onExit: (code) => resolve({ success: code === 0 }),
                 onError: (err) => {
                     safeSendToRenderer('terminal-log', { id: commandId, text: `Error: ${err.message}` });

--- a/src/components/CreateBackupModal.test.tsx
+++ b/src/components/CreateBackupModal.test.tsx
@@ -176,6 +176,30 @@ describe('CreateBackupModal', () => {
         });
     });
 
+    it('displays current file path when onProgress is called during backup', async () => {
+        vi.mocked(borgService.selectDirectory).mockResolvedValue(['C:\\Source']);
+
+        vi.mocked(borgService.createArchive).mockImplementation(
+            async (_url, _archive, _paths, _onLog, overrides) => {
+                overrides?.onProgress?.({ path: '/home/user/documents/report.pdf', nfiles: 7 });
+                return true;
+            }
+        );
+
+        render(<CreateBackupModal {...defaultProps} />);
+
+        const folderBtn = screen.getByRole('button', { name: /browse/i });
+        fireEvent.click(folderBtn);
+        await waitFor(() => screen.getByDisplayValue('C:\\Source'));
+
+        const startBtn = screen.getByRole('button', { name: /start backup/i });
+        fireEvent.click(startBtn);
+
+        await waitFor(() => {
+            expect(borgService.createArchive).toHaveBeenCalled();
+        });
+    });
+
     it('allows cancelling while a backup is running', async () => {
         vi.mocked(borgService.selectDirectory).mockResolvedValue(['C:\\Source']);
 

--- a/src/components/CreateBackupModal.tsx
+++ b/src/components/CreateBackupModal.tsx
@@ -37,6 +37,7 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
   
   const [isProcessing, setIsProcessing] = useState(false);
   const [currentLog, setCurrentLog] = useState('');
+  const [currentFile, setCurrentFile] = useState('');
     const [activeCommandId, setActiveCommandId] = useState<string | null>(null);
     const [isCancelling, setIsCancelling] = useState(false);
 
@@ -60,6 +61,7 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
           setIsProcessing(false);
           setIsCancelling(false);
           setCurrentLog('');
+          setCurrentFile('');
           setActiveCommandId(null);
           cancelledRef.current = false;
       }
@@ -101,9 +103,10 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
 
       setIsProcessing(true);
       setCurrentLog('Initializing backup process...');
+      setCurrentFile('');
       setActiveCommandId(commandId);
       onBackupStarted?.(activeRepo, commandId);
-      
+
       const logs: string[] = [];
       const logCollector = (l: string) => {
           logs.push(l);
@@ -121,7 +124,15 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
               archiveName,
               [sourcePath],
               logCollector,
-              { repoId: activeRepo.id, disableHostCheck: activeRepo.trustHost, remotePath: activeRepo.remotePath, commandId },
+              {
+                  repoId: activeRepo.id,
+                  disableHostCheck: activeRepo.trustHost,
+                  remotePath: activeRepo.remotePath,
+                  commandId,
+                  onProgress: ({ path }) => {
+                      if (isMountedRef.current) setCurrentFile(path);
+                  },
+              },
               ...(excludePatterns.length ? [{ excludePatterns }] : [])
           );
 
@@ -147,6 +158,7 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
           if (isMountedRef.current) {
               setIsProcessing(false);
               setIsCancelling(false);
+              setCurrentFile('');
               setActiveCommandId(null);
           }
       }
@@ -305,6 +317,12 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
                        <div className="font-mono text-xs text-slate-400 truncate flex items-center gap-2">
                            <Terminal className="w-3 h-3" /> {currentLog}
                        </div>
+                       {currentFile && (
+                           <div className="font-mono text-xs text-slate-500 truncate flex items-center gap-1 mt-1 pl-0.5" title={currentFile}>
+                               <span className="text-slate-600 shrink-0">→</span>
+                               <span className="truncate">{currentFile}</span>
+                           </div>
+                       )}
                    </div>
                )}
 

--- a/src/services/borgService.test.ts
+++ b/src/services/borgService.test.ts
@@ -247,6 +247,61 @@ describe('borgService', () => {
             expect(params.envVars.MY_VAR).toBe('123');
             expect(params.envVars.WSLENV).toBeUndefined();
         });
+
+        it('calls onProgress when borg-archive-progress event fires for the matching commandId', async () => {
+            const listeners: Record<string, any> = {};
+            mockOn.mockImplementation((channel: string, fn: any) => {
+                listeners[channel] = fn;
+            });
+
+            mockInvoke.mockImplementation(async (_channel: string, { commandId }: any) => {
+                // Simulate a borg-archive-progress event mid-command
+                if (listeners['borg-archive-progress']) {
+                    listeners['borg-archive-progress']({}, {
+                        id: commandId,
+                        path: '/home/user/documents/file.txt',
+                        nfiles: 42,
+                    });
+                }
+                return { success: true };
+            });
+
+            const onProgress = vi.fn();
+            await borgService.runCommand(['create'], vi.fn(), { commandId: 'progress-test', onProgress });
+
+            expect(onProgress).toHaveBeenCalledWith({ path: '/home/user/documents/file.txt', nfiles: 42 });
+            expect(mockRemoveListener).toHaveBeenCalledWith('borg-archive-progress', expect.any(Function));
+        });
+
+        it('ignores borg-archive-progress events for a different commandId', async () => {
+            const listeners: Record<string, any> = {};
+            mockOn.mockImplementation((channel: string, fn: any) => {
+                listeners[channel] = fn;
+            });
+
+            mockInvoke.mockImplementation(async (_channel: string, _params: any) => {
+                if (listeners['borg-archive-progress']) {
+                    // Fire event with a DIFFERENT id
+                    listeners['borg-archive-progress']({}, {
+                        id: 'other-command',
+                        path: '/some/other/path',
+                        nfiles: 1,
+                    });
+                }
+                return { success: true };
+            });
+
+            const onProgress = vi.fn();
+            await borgService.runCommand(['create'], vi.fn(), { commandId: 'my-command', onProgress });
+
+            expect(onProgress).not.toHaveBeenCalled();
+        });
+
+        it('always removes borg-archive-progress listener on completion even without onProgress', async () => {
+            mockInvoke.mockResolvedValue({ success: true });
+            await borgService.runCommand(['list'], vi.fn());
+            expect(mockRemoveListener).toHaveBeenCalledWith('borg-archive-progress', expect.any(Function));
+        });
     });
 
     describe('createArchive', () => {

--- a/src/services/borgService.ts
+++ b/src/services/borgService.ts
@@ -183,9 +183,9 @@ export const borgService = {
    * Pass repoId in overrides to inject the secure password from backend
    */
   runCommand: async (
-    args: string[], 
+    args: string[],
     onLog: (text: string) => void,
-    overrides?: { repoId?: string, disableHostCheck?: boolean, commandId?: string, forceBinary?: string, cwd?: string, env?: Record<string, string>, remotePath?: string }
+    overrides?: { repoId?: string, disableHostCheck?: boolean, commandId?: string, forceBinary?: string, cwd?: string, env?: Record<string, string>, remotePath?: string, onProgress?: (info: { path: string; nfiles: number }) => void }
   ): Promise<boolean> => {
     const commandId = overrides?.commandId || crypto.randomUUID();
     const config = getBorgConfig();
@@ -250,12 +250,18 @@ export const borgService = {
       onLog(msg.text);
     };
 
+    const progressListener = (_: any, msg: { id: string; path: string; nfiles: number }) => {
+      if (msg.id !== commandId) return;
+      overrides?.onProgress?.({ path: msg.path, nfiles: msg.nfiles });
+    };
+
     getIpc().on('terminal-log', logListener);
+    getIpc().on('borg-archive-progress', progressListener);
 
     try {
-            const result = await getIpc().invoke('borg-spawn', { 
-          args: finalArgs, 
-          commandId, 
+            const result = await getIpc().invoke('borg-spawn', {
+          args: finalArgs,
+          commandId,
           useWsl: config.useWsl,
           executablePath: config.path,
           envVars: finalEnv,
@@ -277,6 +283,7 @@ export const borgService = {
                     }
             }
             getIpc().removeListener('terminal-log', logListener);
+            getIpc().removeListener('borg-archive-progress', progressListener);
     }
   },
 
@@ -811,11 +818,11 @@ export const borgService = {
   },
 
   createArchive: async (
-      repoUrl: string, 
-      archiveName: string, 
-      sourcePaths: string[], 
+      repoUrl: string,
+      archiveName: string,
+      sourcePaths: string[],
       onLog: (text: string) => void,
-      overrides?: { repoId?: string, disableHostCheck?: boolean, remotePath?: string, commandId?: string },
+      overrides?: { repoId?: string, disableHostCheck?: boolean, remotePath?: string, commandId?: string, onProgress?: (info: { path: string; nfiles: number }) => void },
       options?: { excludePatterns?: string[] }
   ): Promise<boolean> => {
       const config = getBorgConfig();


### PR DESCRIPTION
## Summary

- Parses borg's `--progress` stderr output in the main process to extract the currently processed file path
- Emits a new `borg-archive-progress` IPC event per progress frame (`{ id, path, nfiles }`)
- `borgService.runCommand` accepts an optional `onProgress` callback, wires it to that event, and cleans up in `finally`
- `createArchive` exposes `onProgress` and threads it through
- `CreateBackupModal` subscribes and renders the current file path below the status line during backup

**UI during backup:**
```
⟳ Processing Backup...
  [>_] Backing up...
  → /home/user/documents/very-large-file.zip
```

## How it works

Borg writes `--progress` lines to stderr terminated with `\r`:
```
  1.20 kB O   1.20 kB   1.20 kB      1 A /home/user/documents/file.txt
```
The main process buffers these chunks, splits on `\r`/`\n`, matches each segment against a regex for the borg progress format (`SIZE O SIZE SIZE NFILES TYPE PATH`), and emits the structured event. If the regex doesn't match (e.g. different borg version, finalization messages), nothing is emitted and the UI behaves exactly as before — no regression.

## Known limitation

During borg's **finalization phase** (archive commit, cache update) no more progress lines are emitted. `currentFile` will freeze on the last known file until the backup completes. This is still an improvement over the previous behaviour (nothing at all), but the "stuck" feeling can persist at the very end.

## Test plan

- [ ] Run a real `borg create --progress` backup and confirm the current file is displayed in the UI
- [ ] Verify the regex matches actual borg stderr output (format: `SIZE O SIZE SIZE NFILES TYPE PATH`)
- [ ] Confirm no file is shown when borg is in the finalization phase (expected: last file stays visible)
- [ ] Start a backup, cancel mid-way — confirm `currentFile` clears correctly
- [ ] Run a backup to completion — confirm `currentFile` clears on success
- [ ] All 267 unit tests pass (`npm test`)

> ⚠️ **Needs live borg testing before merge.** The progress line regex was written against the documented borg `--progress` format but could not be validated against real borg output in this environment. If the regex doesn't match, `onProgress` simply never fires and the UI falls back to the previous behaviour — but the primary feature won't work until confirmed.