### PR TITLE
fix: stats page scrolling and cut-off chart axis labels (closes #214)

### DIFF
--- a/src/components/StorageChart.test.tsx
+++ b/src/components/StorageChart.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+
+import StorageChart from './StorageChart';
+
+describe('StorageChart', () => {
+  const data = [
+    { date: '2026-06-01T00:00:00Z', size: 100, originalSize: 200 },
+    { date: '2026-06-02T00:00:00Z', size: 150, originalSize: 260 },
+    { date: '2026-06-03T00:00:00Z', size: 220, originalSize: 300 },
+  ];
+
+  it('renders an empty state when there is no data', () => {
+    render(<StorageChart data={[]} />);
+    expect(screen.getByText(/No history data available/i)).toBeInTheDocument();
+  });
+
+  it('renders y-axis labels as HTML in a gutter, not as clippable SVG text', () => {
+    const { container } = render(<StorageChart data={data} />);
+
+    expect(screen.getByText(/Storage Growth/i)).toBeInTheDocument();
+
+    // Baseline label is rendered (as HTML text in the gutter)
+    expect(screen.getByText('0 B')).toBeInTheDocument();
+
+    // Five horizontal grid lines and the plotted line are present
+    expect(container.querySelectorAll('line').length).toBe(5);
+    expect(container.querySelector('polyline')).toBeTruthy();
+
+    // Regression guard for issue #214: axis labels must NOT live inside the
+    // stretched SVG (preserveAspectRatio="none") where they get clipped/distorted.
+    expect(container.querySelectorAll('svg text').length).toBe(0);
+  });
+});

--- a/src/components/StorageChart.tsx
+++ b/src/components/StorageChart.tsx
@@ -46,23 +46,33 @@ const StorageChart: React.FC<StorageChartProps> = ({ data, height = 300 }) => {
     );
   }
 
-  const padding = 40;
+  // Horizontal padding is tiny because the Y-axis labels now live in a separate
+  // HTML gutter (see below). Vertical padding keeps headroom above the peak and a
+  // baseline below. The SVG is stretched (preserveAspectRatio="none"), so anything
+  // we render inside it gets distorted — that's why the labels are kept outside it.
+  const padX = 6;
+  const padY = 24;
   const chartWidth = 800; // Internal coordinate system width
   const chartHeight = height; // Use the prop directly for the SVG viewBox
-  const plotWidth = chartWidth - padding * 2;
-  const plotHeight = chartHeight - padding * 2;
+  const plotWidth = chartWidth - padX * 2;
+  const plotHeight = chartHeight - padY * 2;
+
+  const maxVal = processedData[0]?.max ?? 0;
+  const ticks = [0, 0.25, 0.5, 0.75, 1];
+  // Vertical position (as a fraction of the container) of a given tick / grid line.
+  const topFraction = (t: number) => (chartHeight - padY - t * plotHeight) / chartHeight;
 
   const points = processedData.map(d => {
-    const px = padding + d.x * plotWidth;
-    const py = chartHeight - padding - (d.y * plotHeight);
+    const px = padX + d.x * plotWidth;
+    const py = chartHeight - padY - (d.y * plotHeight);
     return `${px},${py}`;
   }).join(' ');
 
   // Create area path (close the loop down to bottom)
-  const firstX = padding;
-  const lastX = padding + plotWidth;
-  const bottomY = chartHeight - padding;
-  
+  const firstX = padX;
+  const lastX = padX + plotWidth;
+  const bottomY = chartHeight - padY;
+
   const areaPath = `M ${points.split(' ')[0]} L ${points} L ${lastX},${bottomY} L ${firstX},${bottomY} Z`;
 
   return (
@@ -75,19 +85,29 @@ const StorageChart: React.FC<StorageChartProps> = ({ data, height = 300 }) => {
          </div>
       </div>
 
-      <div className="relative flex-1 min-h-0 w-full">
+      <div className="relative flex-1 min-h-0 w-full flex">
+        {/* Y-axis labels: rendered as HTML in a fixed-width gutter so they keep a
+            constant size and never get clipped by the stretched SVG. */}
+        <div className="relative w-14 shrink-0">
+          {ticks.map(t => (
+            <span
+              key={t}
+              className="absolute right-1.5 -translate-y-1/2 whitespace-nowrap text-[10px] tabular-nums text-gray-500"
+              style={{ top: `${topFraction(t) * 100}%` }}
+            >
+              {formatBytes(maxVal * t)}
+            </span>
+          ))}
+        </div>
+
+        <div className="relative flex-1 min-h-0">
         {/* We use preserveAspectRatio="none" to allow stretching to container */}
         <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} preserveAspectRatio="none" className="absolute inset-0 h-full w-full overflow-visible">
           {/* Grid Lines */}
-          {[0, 0.25, 0.5, 0.75, 1].map(t => {
-            const y = chartHeight - padding - (t * plotHeight);
+          {ticks.map(t => {
+            const y = chartHeight - padY - (t * plotHeight);
             return (
-              <g key={t}>
-                <line x1={padding} y1={y} x2={chartWidth - padding} y2={y} stroke="#374151" strokeDasharray="4 4" />
-                <text x={padding - 10} y={y + 4} textAnchor="end" className="text-[10px] fill-gray-500">
-                  {formatBytes(processedData[0]?.max * t || 0)}
-                </text>
-              </g>
+              <line key={t} x1={0} y1={y} x2={chartWidth} y2={y} stroke="#374151" strokeDasharray="4 4" />
             );
           })}
 
@@ -99,8 +119,8 @@ const StorageChart: React.FC<StorageChartProps> = ({ data, height = 300 }) => {
 
           {/* Interactive Points */}
           {processedData.map((d, i) => {
-            const px = padding + d.x * plotWidth;
-            const py = chartHeight - padding - (d.y * plotHeight);
+            const px = padX + d.x * plotWidth;
+            const py = chartHeight - padY - (d.y * plotHeight);
             const isHovered = hoveredIndex === i;
             
             return (
@@ -138,6 +158,7 @@ const StorageChart: React.FC<StorageChartProps> = ({ data, height = 300 }) => {
             );
           })}
         </svg>
+        </div>
       </div>
     </div>
   );

--- a/src/views/RepoDetailsView.tsx
+++ b/src/views/RepoDetailsView.tsx
@@ -165,7 +165,7 @@ const RepoDetailsView: React.FC<RepoDetailsViewProps> = ({ repo, onBack, onSaveR
       currentPaths.join('\n') !== savedConfig.samplePaths.join('\n');
 
   return (
-    <div className="flex flex-col gap-4 h-full overflow-hidden animate-in fade-in duration-300">
+    <div className="flex flex-col gap-4 h-full overflow-y-auto pr-1 animate-in fade-in duration-300">
        {pickerArchive && (
           <ArchiveBrowserModal
              archive={pickerArchive}
@@ -351,7 +351,7 @@ const RepoDetailsView: React.FC<RepoDetailsViewProps> = ({ repo, onBack, onSaveR
        </div>
 
        {/* Chart Section */}
-       <div className="flex-1 w-full min-h-0 flex flex-col">
+       <div className="flex-1 w-full min-h-[320px] flex flex-col">
           {loadingChart ? (
              <div className="h-full w-full flex flex-col items-center justify-center text-slate-500 dark:text-gray-500 gap-4">
                 <Loader2 className="h-8 w-8 animate-spin text-blue-500" />


### PR DESCRIPTION
Fixes #214 (both reported problems).

### 1. Missing vertical scroll-bar
The Repository Stats page used `h-full overflow-hidden` on the root while the chart was `flex-1 min-h-0`. On a non-maximized window the fixed sections (stats, recovery, heatmap) ate the available height, the chart collapsed toward 0, and everything below was **clipped instead of scrollable** — so the heatmap and growth plot were only visible when maximized.

- Root: `overflow-hidden` → **`overflow-y-auto`** (page scrolls when it doesn't fit).
- Chart section: `min-h-0` → **`min-h-[320px]`** so it keeps a usable height and pushes the page into a scroll instead of collapsing. It still `flex-1`-grows to fill on large windows.

### 2. Cut-off left axis labels
The Y-axis labels were rendered **inside** an SVG stretched with `preserveAspectRatio="none"`, so on narrow widths their positions/glyphs were squeezed toward the left edge and clipped (the collapsing height from #1 made it worse).

- Moved the Y-axis labels into a **fixed-width HTML gutter** aligned to the grid lines — constant size, never clipped.
- Grid lines now span the full plot width.

### Tests
- New `StorageChart.test.tsx` (the component had none), including a regression guard that axis labels are **not** SVG `<text>` nodes.
- Full suite green: typecheck, **272 unit tests**, build.

### ⚠️ Needs a visual check
I can't launch Electron in CI/sandbox, so I verified this by reasoning + build/tests, not by eye. @nhansendev offered to test pre-release — the layout math is straightforward, but a quick look on a non-maximized window (and the axis labels) would be the final confirmation.