### PR TITLE
Fix error on Borg warning.

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -1720,11 +1720,13 @@ ipcMain.handle('borg-spawn', async (event, { args, commandId, useWsl, executable
                 // on exit 1 meaning "no lock", which must not be read as success.
                 onExit: (code) => {
                     const isBorg = !forceBinary || forceBinary === 'borg';
-                    resolve({ success: code === 0 || (isBorg && code === 1) });
+                    // Expose the raw exit code so callers can distinguish a clean success
+                    // (0) from a warning (1) — see borgService.runCommand's onResult.
+                    resolve({ success: code === 0 || (isBorg && code === 1), code });
                 },
                 onError: (err) => {
                     safeSendToRenderer('terminal-log', { id: commandId, text: `Error: ${err.message}` });
-                    resolve({ success: false, error: err.message });
+                    resolve({ success: false, error: err.message, code: null });
                 }
             });
         });

--- a/electron-main.js
+++ b/electron-main.js
@@ -1711,7 +1711,17 @@ ipcMain.handle('borg-spawn', async (event, { args, commandId, useWsl, executable
                 // Renderer may implement its own deadline logic and call borg-stop.
                 onStdout: (data) => safeSendToRenderer('terminal-log', { id: commandId, text: data.toString() }),
                 onStderr: handleStderr,
-                onExit: (code) => resolve({ success: code === 0 }),
+                // Borg exit codes: 0 = success, 1 = warning (e.g. a file vanished or
+                // changed while being read), >=2 = error. Treat a warning as success so a
+                // benign warning doesn't fail an otherwise-good backup, matching the
+                // scheduled-job path (runBorgInternal). This relaxation applies ONLY to real
+                // borg invocations: forced helper binaries (ssh/bash/mkdir) keep strict
+                // code===0 semantics — e.g. the SSH `test -e lock.roster` lock probe relies
+                // on exit 1 meaning "no lock", which must not be read as success.
+                onExit: (code) => {
+                    const isBorg = !forceBinary || forceBinary === 'borg';
+                    resolve({ success: code === 0 || (isBorg && code === 1) });
+                },
                 onError: (err) => {
                     safeSendToRenderer('terminal-log', { id: commandId, text: `Error: ${err.message}` });
                     resolve({ success: false, error: err.message });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1226,7 +1226,7 @@ const App: React.FC = () => {
           : [job.sourcePath];
 
       try {
-          const success = await borgService.createArchive(
+          const { success, warning } = await borgService.createArchive(
               repo.url,
               archiveName,
               effectiveSourcePaths,
@@ -1236,9 +1236,16 @@ const App: React.FC = () => {
           );
 
           if (success) {
-              addActivity('Backup Job Success', `Created archive: ${archiveName}`, 'success');
-              toast.success(`Job '${job.name}' finished successfully!`);
-              
+              // A borg warning (exit 1) still produces a valid archive — record it as a
+              // successful run but surface the warning so it isn't silently treated as clean.
+              if (warning) {
+                  addActivity('Backup Job Warning', `Archive created with warnings: ${archiveName}`, 'warning');
+                  toast.warning(`Job '${job.name}' finished with warnings. Check activity log.`);
+              } else {
+                  addActivity('Backup Job Success', `Created archive: ${archiveName}`, 'success');
+                  toast.success(`Job '${job.name}' finished successfully!`);
+              }
+
               if (job.pruneEnabled) {
                   addActivity('Auto Prune Started', `Pruning repo for job ${job.name}...`, 'info');
                   const pruneSuccess = await borgService.prune(

--- a/src/components/CreateBackupModal.test.tsx
+++ b/src/components/CreateBackupModal.test.tsx
@@ -87,15 +87,15 @@ describe('CreateBackupModal', () => {
 
     it('calls createArchive with correct parameters on submit', async () => {
         vi.mocked(borgService.selectDirectory).mockResolvedValue(['C:\\Source']);
-        vi.mocked(borgService.createArchive).mockResolvedValue(true);
-        
+        vi.mocked(borgService.createArchive).mockResolvedValue({ success: true, warning: false });
+
         render(<CreateBackupModal {...defaultProps} />);
-        
+
         // Select folder
         const folderBtn = screen.getByRole('button', { name: /browse/i });
         fireEvent.click(folderBtn);
         await waitFor(() => screen.getByDisplayValue('C:\\Source'));
-        
+
         // Change name (targeting input by placeholder or value)
         // Code from turn 4: `const [archiveName, setArchiveName] = useState(...)`
         // It usually has a default value like `backup-YYYY-...`.
@@ -125,7 +125,7 @@ describe('CreateBackupModal', () => {
 
     it('handles backup failure', async () => {
         vi.mocked(borgService.selectDirectory).mockResolvedValue(['C:\\Source']);
-        vi.mocked(borgService.createArchive).mockResolvedValue(false); // Simulate fail
+        vi.mocked(borgService.createArchive).mockResolvedValue({ success: false, warning: false }); // Simulate fail
         
         render(<CreateBackupModal {...defaultProps} />);
         
@@ -147,7 +147,7 @@ describe('CreateBackupModal', () => {
 
     it('passes exclude patterns to createArchive when provided', async () => {
         vi.mocked(borgService.selectDirectory).mockResolvedValue(['C:\\Source']);
-        vi.mocked(borgService.createArchive).mockResolvedValue(true);
+        vi.mocked(borgService.createArchive).mockResolvedValue({ success: true, warning: false });
 
         render(<CreateBackupModal {...defaultProps} />);
 
@@ -182,7 +182,7 @@ describe('CreateBackupModal', () => {
         vi.mocked(borgService.createArchive).mockImplementation(
             async (_url, _archive, _paths, _onLog, overrides) => {
                 overrides?.onProgress?.({ path: '/home/user/documents/report.pdf', nfiles: 7 });
-                return true;
+                return { success: true, warning: false };
             }
         );
 
@@ -203,8 +203,8 @@ describe('CreateBackupModal', () => {
     it('allows cancelling while a backup is running', async () => {
         vi.mocked(borgService.selectDirectory).mockResolvedValue(['C:\\Source']);
 
-        let resolveCreate: (v: boolean) => void;
-        const createPromise = new Promise<boolean>((resolve) => {
+        let resolveCreate: (v: { success: boolean; warning: boolean }) => void;
+        const createPromise = new Promise<{ success: boolean; warning: boolean }>((resolve) => {
             resolveCreate = resolve;
         });
         vi.mocked(borgService.createArchive).mockReturnValue(createPromise as any);
@@ -234,7 +234,7 @@ describe('CreateBackupModal', () => {
 
         // Allow promise to resolve to avoid pending promise leakage
         await act(async () => {
-            resolveCreate!(false);
+            resolveCreate!({ success: false, warning: false });
         });
     });
 });

--- a/src/components/CreateBackupModal.tsx
+++ b/src/components/CreateBackupModal.tsx
@@ -119,7 +119,7 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
               .map(p => p.trim())
               .filter(Boolean);
 
-          const success = await borgService.createArchive(
+          const { success, warning } = await borgService.createArchive(
               activeRepo.url,
               archiveName,
               [sourcePath],
@@ -140,7 +140,14 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
           if (cancelledRef.current) return;
 
           if (success) {
-              toast.success(`Backup '${archiveName}' created successfully!`);
+              // Borg exited with a warning (e.g. a file changed/vanished mid-backup):
+              // the archive was still created, so this is a success-with-caveat, not a failure.
+              if (warning) {
+                  toast.warning(`Backup '${archiveName}' completed with warnings. See logs for details.`);
+                  onLog(`Backup completed with warnings: ${archiveName}`, logs);
+              } else {
+                  toast.success(`Backup '${archiveName}' created successfully!`);
+              }
               onBackupFinished?.(activeRepo, 'success', Date.now() - startTime);
               onSuccess();
               onClose();

--- a/src/components/ToastContainer.tsx
+++ b/src/components/ToastContainer.tsx
@@ -1,11 +1,11 @@
 
 import React, { useState, useEffect } from 'react';
-import { CheckCircle2, AlertCircle, Info, X, Loader2 } from 'lucide-react';
+import { CheckCircle2, AlertCircle, AlertTriangle, Info, X, Loader2 } from 'lucide-react';
 
 interface Toast {
   id: string;
   message: string;
-  type: 'success' | 'error' | 'info' | 'loading';
+  type: 'success' | 'error' | 'warning' | 'info' | 'loading';
   duration?: number;
 }
 
@@ -49,16 +49,19 @@ export const ToastContainer: React.FC = () => {
           className={`pointer-events-auto min-w-[300px] max-w-md p-4 rounded-xl shadow-lg border backdrop-blur-md flex items-start gap-3 animate-in slide-in-from-right-10 fade-in duration-300 ${
             toast.type === 'success' ? 'bg-white/90 dark:bg-slate-800/90 border-green-500/30 text-slate-800 dark:text-slate-100 shadow-green-500/10' :
             toast.type === 'error' ? 'bg-white/90 dark:bg-slate-800/90 border-red-500/30 text-slate-800 dark:text-slate-100 shadow-red-500/10' :
+            toast.type === 'warning' ? 'bg-white/90 dark:bg-slate-800/90 border-amber-500/30 text-slate-800 dark:text-slate-100 shadow-amber-500/10' :
             'bg-white/90 dark:bg-slate-800/90 border-blue-500/30 text-slate-800 dark:text-slate-100 shadow-blue-500/10'
           }`}
         >
           <div className={`mt-0.5 ${
             toast.type === 'success' ? 'text-green-500' :
             toast.type === 'error' ? 'text-red-500' :
+            toast.type === 'warning' ? 'text-amber-500' :
             'text-blue-500'
           }`}>
             {toast.type === 'success' && <CheckCircle2 size={18} />}
             {toast.type === 'error' && <AlertCircle size={18} />}
+            {toast.type === 'warning' && <AlertTriangle size={18} />}
             {toast.type === 'info' && <Info size={18} />}
             {toast.type === 'loading' && <Loader2 size={18} className="animate-spin" />}
           </div>

--- a/src/services/borgService.test.ts
+++ b/src/services/borgService.test.ts
@@ -302,6 +302,25 @@ describe('borgService', () => {
             await borgService.runCommand(['list'], vi.fn());
             expect(mockRemoveListener).toHaveBeenCalledWith('borg-archive-progress', expect.any(Function));
         });
+
+        it('reports a warning to onResult when borg exits 1 (warning), still returning success', async () => {
+            mockInvoke.mockResolvedValue({ success: true, code: 1 });
+            const onResult = vi.fn();
+
+            const ok = await borgService.runCommand(['create', 'repo::a'], vi.fn(), { onResult });
+
+            expect(ok).toBe(true);
+            expect(onResult).toHaveBeenCalledWith({ success: true, code: 1, warning: true });
+        });
+
+        it('reports no warning to onResult on a clean exit (code 0)', async () => {
+            mockInvoke.mockResolvedValue({ success: true, code: 0 });
+            const onResult = vi.fn();
+
+            await borgService.runCommand(['create', 'repo::a'], vi.fn(), { onResult });
+
+            expect(onResult).toHaveBeenCalledWith({ success: true, code: 0, warning: false });
+        });
     });
 
     describe('createArchive', () => {
@@ -326,7 +345,7 @@ describe('borgService', () => {
             expect(spy).toHaveBeenCalledWith(
                 expect.arrayContaining(['create', '--progress', '--stats']),
                 onLog,
-                undefined
+                expect.objectContaining({ onResult: expect.any(Function) })
             );
 
             const calledArgs = spy.mock.calls[0][0];
@@ -355,6 +374,24 @@ describe('borgService', () => {
             const calledArgs = spy.mock.calls[0][0];
             expect(calledArgs).not.toContain('--exclude');
             spy.mockRestore();
+        });
+
+        it('surfaces a borg warning (exit 1) as success-with-warning', async () => {
+            mockInvoke.mockResolvedValue({ success: true, code: 1 });
+            const result = await borgService.createArchive('ssh://repo', 'arch-warn', ['C:\\Data'], vi.fn());
+            expect(result).toEqual({ success: true, warning: true });
+        });
+
+        it('reports a clean backup (exit 0) without a warning', async () => {
+            mockInvoke.mockResolvedValue({ success: true, code: 0 });
+            const result = await borgService.createArchive('ssh://repo', 'arch-ok', ['C:\\Data'], vi.fn());
+            expect(result).toEqual({ success: true, warning: false });
+        });
+
+        it('reports a failed backup (exit >=2) as failure with no warning', async () => {
+            mockInvoke.mockResolvedValue({ success: false, code: 2 });
+            const result = await borgService.createArchive('ssh://repo', 'arch-fail', ['C:\\Data'], vi.fn());
+            expect(result).toEqual({ success: false, warning: false });
         });
     });
 

--- a/src/services/borgService.ts
+++ b/src/services/borgService.ts
@@ -185,7 +185,7 @@ export const borgService = {
   runCommand: async (
     args: string[],
     onLog: (text: string) => void,
-    overrides?: { repoId?: string, disableHostCheck?: boolean, commandId?: string, forceBinary?: string, cwd?: string, env?: Record<string, string>, remotePath?: string, onProgress?: (info: { path: string; nfiles: number }) => void }
+    overrides?: { repoId?: string, disableHostCheck?: boolean, commandId?: string, forceBinary?: string, cwd?: string, env?: Record<string, string>, remotePath?: string, onProgress?: (info: { path: string; nfiles: number }) => void, onResult?: (result: { success: boolean; code: number | null; warning: boolean }) => void }
   ): Promise<boolean> => {
     const commandId = overrides?.commandId || crypto.randomUUID();
     const config = getBorgConfig();
@@ -269,7 +269,13 @@ export const borgService = {
           repoId: overrides?.repoId, // SECURE INJECTION TRIGGER
           cwd: overrides?.cwd
       });
-      return result.success;
+      // Surface the raw exit code so callers can tell a clean success (0) apart from a
+      // borg warning (1, archive still created). main treats exit 1 as success, so a
+      // truthy `success` with a non-zero code is a warning rather than a hard failure.
+      const code: number | null = typeof result?.code === 'number' ? result.code : null;
+      const success = !!result.success;
+      overrides?.onResult?.({ success, code, warning: success && code !== null && code !== 0 });
+      return success;
     } finally {
             // Fallback: if we showed a queue toast but never saw any further output,
             // ensure it gets dismissed when the command finishes.
@@ -824,7 +830,7 @@ export const borgService = {
       onLog: (text: string) => void,
       overrides?: { repoId?: string, disableHostCheck?: boolean, remotePath?: string, commandId?: string, onProgress?: (info: { path: string; nfiles: number }) => void },
       options?: { excludePatterns?: string[] }
-  ): Promise<boolean> => {
+  ): Promise<{ success: boolean; warning: boolean }> => {
       const config = getBorgConfig();
       
       // Convert paths for WSL if needed
@@ -862,8 +868,15 @@ export const borgService = {
 
       // Create command: borg create --progress --stats REPO::ARCHIVE PATHS...
       const args = ['create', '--progress', '--stats', ...excludeArgs, `${repoUrl}::${archiveName}`, ...paths];
-      
-      return await borgService.runCommand(args, onLog, overrides);
+
+      // Capture whether borg exited with a warning (code 1) so the UI can report
+      // "completed with warnings" instead of a plain success.
+      let warning = false;
+      const success = await borgService.runCommand(args, onLog, {
+          ...overrides,
+          onResult: (r) => { warning = r.warning; },
+      });
+      return { success, warning };
   },
 
   notify: (title: string, body: string) => {

--- a/src/utils/eventBus.ts
+++ b/src/utils/eventBus.ts
@@ -1,5 +1,5 @@
 
-type ToastType = 'success' | 'error' | 'info' | 'loading';
+type ToastType = 'success' | 'error' | 'warning' | 'info' | 'loading';
 
 interface ToastEventDetail {
   id: string;
@@ -27,6 +27,7 @@ export const toast = {
   },
   success: (msg: string) => toast.show(msg, 'success'),
   error: (msg: string) => toast.show(msg, 'error', 6000),
+  warning: (msg: string) => toast.show(msg, 'warning', 6000),
   info: (msg: string) => toast.show(msg, 'info'),
   loading: (msg: string) => toast.show(msg, 'loading', 0) // 0 = persistent
 };


### PR DESCRIPTION
## Summary

Borg spits out warnings on some common cases, including permission-denied and file-vanished. Borgmon interprets anything except pure success as failure. This adds awareness of "warning" so it can continue past a warning.

## What changed

Two commits here.

The first one is the functionality change; we accept warnings and turn them into successes.

The second, far larger one, is UI; we expose warnings to the UI instead of swallowing them.

## How to test
- [X] `npm ci`
- [X] `npx vitest run` (pre-existing error; everything else green)
- [X] `npm run build`
- [ ] `npm run test:e2e` (when relevant) (didn't seem to work properly on main, I may not have set this up correctly)

## Risk areas (check if touched)
- [ ] WSL installation / WSL detection
- [X] Borg install / borg invocation
- [ ] SSH key management / SSH deploy
- [ ] Secrets/passphrase handling

## Notes

They're trying to back up their user profile and a bunch of stuff in there is locked. An example:

`/mnt/d/Dropbox/Users/REDACTED/AppData/Local/Packages/Microsoft.Windows.Search_cw5n1h2txyewy/Settings/settings.dat: open: [Errno 13] Permission denied: 'settings.dat'`

(yes their user profile is in an old dropbox folder; they're not actually using dropbox anymore)



I am not wedded to this code and if you want to reimplement it yourself, go wild, I won't be offended; the fix was the important thing, and I'm happy as long as something that solves the same problem ends up in the final result.