### PR TITLE
fix: patch high-severity prod advisories (js-yaml, builder-util-runtime)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "winborg-manager",
       "version": "1.8.2",
       "dependencies": {
-        "electron-updater": "^6.8.3",
+        "electron-updater": "^6.8.9",
         "nodemailer": "^9.0.1"
       },
       "devDependencies": {
@@ -3600,8 +3600,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/argv-formatter": {
       "version": "1.0.0",
@@ -3927,6 +3926,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -5460,12 +5460,11 @@
       "license": "ISC"
     },
     "node_modules/electron-updater": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
-      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
-      "license": "MIT",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "dependencies": {
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -5473,6 +5472,18 @@
         "lodash.isequal": "^4.5.0",
         "semver": "~7.7.3",
         "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {
@@ -7170,9 +7181,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     }
   },
   "dependencies": {
-    "electron-updater": "^6.8.3",
+    "electron-updater": "^6.8.9",
     "nodemailer": "^9.0.1"
   },
   "devDependencies": {
@@ -105,6 +105,6 @@
     "undici": "7.28.0",
     "diff": "8.0.3",
     "axios": "1.16.0",
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## Summary

The CI `test` job fails at the **Security: Audit production dependencies (high+)** step (`npm audit --omit=dev --audit-level=high`), which has been red on `main` (incl. nightly runs) independently of any code change. Because `release` has `needs: test`, this **blocks Semantic Release entirely** — no releases can be cut until the audit gate is green again.

## Root cause & fix

Three high-severity advisories, all reachable through `electron-updater`:

| Advisory | Package | Fix |
|---|---|---|
| [GHSA-p2f4-r6v6-j797](https://github.com/advisories/GHSA-p2f4-r6v6-j797) | `builder-util-runtime <9.7.0` | bump `electron-updater` `^6.8.3` → `^6.8.9` (pulls `builder-util-runtime@9.7.0`) |
| [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | `js-yaml 4.0.0–4.2.0` | existing pinned override was `4.2.0` (still vulnerable) → bump to `4.3.0` |

Change is limited to `package.json` (two lines) and the resulting `package-lock.json`.

## Verification (local)
- [X] `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities** (exit 0)
- [X] `npm run typecheck`
- [X] `npm run test:coverage` → 277 passed, 1 skipped
- [X] `npm run build`
- [ ] E2E could not run in the sandbox (Electron cannot launch here); relying on CI for the smoke suite.

## Risk areas
- [X] Borg install / borg invocation — none; dependency-only change. `electron-updater` is the auto-update client; `js-yaml` bump is a patch within 4.x.