### PR TITLE
chore(deps-dev): bump electron 42 → 43 (supersedes #225)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@vitest/coverage-v8": "^4.1.10",
         "concurrently": "^10.0.4",
         "cross-env": "^10.1.0",
-        "electron": "^42.4.1",
+        "electron": "^43.2.0",
         "electron-builder": "^26.15.3",
         "jsdom": "^29.1.1",
         "lucide-react": "^1.27.0",
@@ -4576,9 +4576,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.1.tgz",
-      "integrity": "sha512-8CYHJP5O4wFO+ycoJR98yy907MmPeo+vWXrzjxmGGgRNKqv8pOjjm+wphO0CCgQJnBU7+QUPSJS4QXhbKrO50w==",
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
+      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
       "dev": true,
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^10.0.4",
     "cross-env": "^10.1.0",
-    "electron": "^42.4.1",
+    "electron": "^43.2.0",
     "electron-builder": "^26.15.3",
     "jsdom": "^29.1.1",
     "lucide-react": "^1.27.0",


### PR DESCRIPTION
## Summary

Isolated major-version bump of **Electron 42.4.1 → 43.2.0**, kept separate from the batch dep update (#237) because a major Electron bump carries real breakage risk (app launch under new Chromium, native ABI, electron-builder packaging).

## Verification
- [X] `npm run typecheck`
- [X] `npm run test:coverage` → 277 passed, 1 skipped
- [X] `npm run build`
- [X] `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities
- [ ] **E2E (app launch)** and **Windows dist build** — validated by CI (sandbox cannot launch Electron). These are the decisive checks for a major Electron bump.

Supersedes #225. Will merge only if CI (incl. smoke E2E + Windows build) is green.