### PR TITLE
feat: view borg output for backup runs in the activity log

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -1076,7 +1076,7 @@ const MAX_ACTIVITY_OUTPUT_CHARS = 10000;
 
 function truncateActivityOutput(text, maxChars = MAX_ACTIVITY_OUTPUT_CHARS) {
     if (!text) return '';
-    const str = String(text);
+    const str = String(text).replace(/\r\n?/g, '\n');
     if (str.length <= maxChars) return str;
     const dropped = str.length - maxChars;
     return `[... ${dropped} earlier characters omitted ...]\n${str.slice(-maxChars)}`;

--- a/electron-main.js
+++ b/electron-main.js
@@ -1069,6 +1069,19 @@ function extractBorgErrorSummary(output) {
     }
 }
 
+// Output attached to an activity entry is persisted in data.json, so cap it.
+// Keep the tail: that is where borg puts the summary and the last warnings.
+// Mirrors truncateActivityOutput() in src/utils/formatters.ts.
+const MAX_ACTIVITY_OUTPUT_CHARS = 10000;
+
+function truncateActivityOutput(text, maxChars = MAX_ACTIVITY_OUTPUT_CHARS) {
+    if (!text) return '';
+    const str = String(text);
+    if (str.length <= maxChars) return str;
+    const dropped = str.length - maxChars;
+    return `[... ${dropped} earlier characters omitted ...]\n${str.slice(-maxChars)}`;
+}
+
 function runBorgInternal(args, { repo, repoId, useWsl, wslDistro, jobName, commandId } = {}) {
     const queueKey = inferBorgQueueKey(args, repoId) || (repo && repo.url) || 'global';
     return enqueueBorgByKey(queueKey, () => new Promise((resolve) => {
@@ -1131,10 +1144,12 @@ function runBorgInternal(args, { repo, repoId, useWsl, wslDistro, jobName, comma
             const success = code === 0 || isWarning;
             const summary = extractBorgErrorSummary(output);
             safeSendToRenderer('activity-log', {
-                title: success ? 'Scheduled Backup Success' : 'Scheduled Backup Failed',
+                title: success
+                    ? (isWarning ? 'Scheduled Backup Warning' : 'Scheduled Backup Success')
+                    : 'Scheduled Backup Failed',
                 detail: summary ? `${jobName} - Code ${code}: ${summary}` : `${jobName} - Code ${code}`,
                 status: success ? (isWarning ? 'warning' : 'success') : 'error',
-                cmd: output
+                cmd: truncateActivityOutput(output)
             });
             resolve({ success, output: output });
         });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import FuseSetupModal from './components/FuseSetupModal';
 import CreateBackupModal from './components/CreateBackupModal';
 import { View, Repository, MountPoint, Archive, ActivityLogEntry, BackupJob, SshConnection, RecoveryDrillConfig } from './types';
 import { borgService } from './services/borgService';
-import { formatDate } from './utils/formatters';
+import { formatDate, truncateActivityOutput } from './utils/formatters';
 import { ToastContainer } from './components/ToastContainer';
 import { toast } from './utils/eventBus';
 import { Loader2 } from 'lucide-react';
@@ -1220,6 +1220,9 @@ const App: React.FC = () => {
 
       const logs: string[] = [];
       const logCollector = (l: string) => logs.push(l);
+      // Keep the borg output with the activity entry so it can be reviewed later,
+      // e.g. to find out what a run with warnings actually complained about.
+      const collectedOutput = () => truncateActivityOutput(logs.join(''));
 
       const effectiveSourcePaths = (job.sourcePaths && job.sourcePaths.length)
           ? job.sourcePaths
@@ -1239,10 +1242,10 @@ const App: React.FC = () => {
               // A borg warning (exit 1) still produces a valid archive — record it as a
               // successful run but surface the warning so it isn't silently treated as clean.
               if (warning) {
-                  addActivity('Backup Job Warning', `Archive created with warnings: ${archiveName}`, 'warning');
+                  addActivity('Backup Job Warning', `Archive created with warnings: ${archiveName}`, 'warning', collectedOutput());
                   toast.warning(`Job '${job.name}' finished with warnings. Check activity log.`);
               } else {
-                  addActivity('Backup Job Success', `Created archive: ${archiveName}`, 'success');
+                  addActivity('Backup Job Success', `Created archive: ${archiveName}`, 'success', collectedOutput());
                   toast.success(`Job '${job.name}' finished successfully!`);
               }
 
@@ -1257,7 +1260,7 @@ const App: React.FC = () => {
                   if (pruneSuccess) {
                       addActivity('Auto Prune Success', `Repository pruned according to retention policy.`, 'success');
                   } else {
-                      addActivity('Auto Prune Failed', `Pruning step failed. Check logs.`, 'warning');
+                      addActivity('Auto Prune Failed', `Pruning step failed. Check logs.`, 'warning', collectedOutput());
                   }
               }
 
@@ -1271,13 +1274,13 @@ const App: React.FC = () => {
           } else {
               finishRepoBackup(repo, 'error', Date.now() - startTime);
               setJobs(prev => prev.map(j => j.id === jobId ? { ...j, status: 'error' } : j));
-              addActivity('Backup Job Failed', `Job: ${job.name} failed`, 'error');
+              addActivity('Backup Job Failed', `Job: ${job.name} failed`, 'error', collectedOutput());
               toast.error(`Job '${job.name}' failed. Check activity log.`);
           }
       } catch (e: any) {
           finishRepoBackup(repo, 'error', Date.now() - startTime);
           setJobs(prev => prev.map(j => j.id === jobId ? { ...j, status: 'error' } : j));
-          addActivity('Backup Job Error', e.message, 'error');
+          addActivity('Backup Job Error', e.message, 'error', collectedOutput());
           toast.error(`Job '${job.name}' error: ${e.message}`);
       }
   };
@@ -1461,7 +1464,12 @@ const App: React.FC = () => {
               repos={repos} 
               isOpen={backupModal.isOpen}
               onClose={() => setBackupModal(prev => prev ? { ...prev, isOpen: false } : prev)}
-              onLog={() => {}}
+              onLog={(title, logs, status) => addActivity(
+                  status === 'warning' ? 'Backup Finished With Warnings' : 'Backup Failed',
+                  title,
+                  status || 'error',
+                  truncateActivityOutput(logs.join(''))
+              )}
               onSuccess={() => { /* handled via onBackupFinished */ }}
               onBackupStarted={(repo, commandId) => startRepoBackup(repo, commandId)}
               onBackupFinished={(repo, result, durationMs) => {

--- a/src/components/CreateBackupModal.tsx
+++ b/src/components/CreateBackupModal.tsx
@@ -12,7 +12,7 @@ interface CreateBackupModalProps {
   repos?: Repository[]; // List of all available connected repos
   isOpen: boolean;
   onClose: () => void;
-  onLog: (title: string, logs: string[]) => void;
+  onLog: (title: string, logs: string[], status?: 'warning' | 'error') => void;
   onSuccess: () => void;
 
     // Optional lifecycle hooks so parent can show global running state/ETA
@@ -144,7 +144,7 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
               // the archive was still created, so this is a success-with-caveat, not a failure.
               if (warning) {
                   toast.warning(`Backup '${archiveName}' completed with warnings. See logs for details.`);
-                  onLog(`Backup completed with warnings: ${archiveName}`, logs);
+                  onLog(`Backup completed with warnings: ${archiveName}`, logs, 'warning');
               } else {
                   toast.success(`Backup '${archiveName}' created successfully!`);
               }
@@ -153,7 +153,7 @@ const CreateBackupModal: React.FC<CreateBackupModalProps> = ({ initialRepo, repo
               onClose();
           } else {
               toast.error("Backup failed. See logs for details.");
-              onLog(`Backup Failed: ${archiveName}`, logs);
+              onLog(`Backup Failed: ${archiveName}`, logs, 'error');
               onBackupFinished?.(activeRepo, 'error', Date.now() - startTime);
           }
       } catch (e: any) {

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,6 +1,6 @@
 
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import { formatBytes, formatDuration, parseSizeString, formatDate, getNextRunForRepo } from './formatters';
+import { formatBytes, formatDuration, parseSizeString, formatDate, getNextRunForRepo, truncateActivityOutput, MAX_ACTIVITY_OUTPUT_CHARS } from './formatters';
 import { BackupJob } from '../types';
 
 const createMockJob = (overrides: Partial<BackupJob>): BackupJob => ({
@@ -32,6 +32,25 @@ describe('formatters', () => {
 
     afterEach(() => {
         vi.useRealTimers();
+    });
+
+    describe('truncateActivityOutput', () => {
+        it('returns short output unchanged', () => {
+            expect(truncateActivityOutput('all good')).toBe('all good');
+        });
+
+        it('handles empty input', () => {
+            expect(truncateActivityOutput('')).toBe('');
+        });
+
+        it('keeps the tail and marks how much was dropped', () => {
+            const text = 'x'.repeat(MAX_ACTIVITY_OUTPUT_CHARS) + 'SUMMARY';
+            const result = truncateActivityOutput(text);
+
+            expect(result).toContain('SUMMARY');
+            expect(result).toContain('[... 7 earlier characters omitted ...]');
+            expect(result.length).toBeLessThan(text.length + 100);
+        });
     });
 
     describe('parseSizeString', () => {

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -43,6 +43,10 @@ describe('formatters', () => {
             expect(truncateActivityOutput('')).toBe('');
         });
 
+        it('turns carriage-return progress frames into separate lines', () => {
+            expect(truncateActivityOutput('frame one\rframe two\r\nframe three')).toBe('frame one\nframe two\nframe three');
+        });
+
         it('keeps the tail and marks how much was dropped', () => {
             const text = 'x'.repeat(MAX_ACTIVITY_OUTPUT_CHARS) + 'SUMMARY';
             const result = truncateActivityOutput(text);

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -64,6 +64,19 @@ export const formatDate = (isoString: string): string => {
     }
 };
 
+// Borg output is stored alongside activity log entries and therefore ends up in
+// data.json. Cap it so a chatty run (or one with thousands of warning lines)
+// can't bloat the database. The tail is kept because that is where borg puts
+// the summary and the last warnings.
+export const MAX_ACTIVITY_OUTPUT_CHARS = 10000;
+
+export const truncateActivityOutput = (text: string, maxChars = MAX_ACTIVITY_OUTPUT_CHARS): string => {
+    if (!text) return '';
+    if (text.length <= maxChars) return text;
+    const dropped = text.length - maxChars;
+    return `[... ${dropped} earlier characters omitted ...]\n${text.slice(-maxChars)}`;
+};
+
 export const formatDuration = (seconds: number): string => {
     if (seconds < 60) return `${seconds.toFixed(1)}s`;
     const minutes = Math.floor(seconds / 60);

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -72,9 +72,12 @@ export const MAX_ACTIVITY_OUTPUT_CHARS = 10000;
 
 export const truncateActivityOutput = (text: string, maxChars = MAX_ACTIVITY_OUTPUT_CHARS): string => {
     if (!text) return '';
-    if (text.length <= maxChars) return text;
-    const dropped = text.length - maxChars;
-    return `[... ${dropped} earlier characters omitted ...]\n${text.slice(-maxChars)}`;
+    // borg --progress redraws its status with carriage returns. Those render
+    // unpredictably in a <pre>, so turn every frame into its own line.
+    const normalized = text.replace(/\r\n?/g, '\n');
+    if (normalized.length <= maxChars) return normalized;
+    const dropped = normalized.length - maxChars;
+    return `[... ${dropped} earlier characters omitted ...]\n${normalized.slice(-maxChars)}`;
 };
 
 export const formatDuration = (seconds: number): string => {

--- a/src/views/ActivityView.test.tsx
+++ b/src/views/ActivityView.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import ActivityView from './ActivityView';
+import { ActivityLogEntry } from '../types';
+
+vi.mock('../components/Button', () => ({
+  default: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} data-testid="mock-button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+const withOutput: ActivityLogEntry = {
+  id: 'log-1',
+  title: 'Backup Job Warning',
+  detail: 'Archive created with warnings: daily-2026-08-11-0300',
+  time: new Date().toISOString(),
+  status: 'warning',
+  cmd: 'file changed while we backed it up: C:/Users/demo/ntuser.dat\nArchive name: daily-2026-08-11-0300',
+};
+
+const withoutOutput: ActivityLogEntry = {
+  id: 'log-2',
+  title: 'Backup Job Started',
+  detail: 'Job: Daily (Repo: Main)',
+  time: new Date().toISOString(),
+  status: 'info',
+};
+
+describe('ActivityView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('keeps the borg output collapsed until the user asks for it', () => {
+    render(<ActivityView logs={[withOutput]} onClearLogs={vi.fn()} />);
+
+    expect(screen.queryByText(/file changed while we backed it up/)).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: /show output/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByText(/file changed while we backed it up/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /hide output/i })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('collapses the output again on a second click', () => {
+    render(<ActivityView logs={[withOutput]} onClearLogs={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /show output/i }));
+    fireEvent.click(screen.getByRole('button', { name: /hide output/i }));
+
+    expect(screen.queryByText(/file changed while we backed it up/)).not.toBeInTheDocument();
+  });
+
+  test('offers no toggle for entries without output', () => {
+    render(<ActivityView logs={[withoutOutput]} onClearLogs={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /show output/i })).not.toBeInTheDocument();
+  });
+
+  test('copies the output to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<ActivityView logs={[withOutput]} onClearLogs={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /show output/i }));
+    fireEvent.click(screen.getByRole('button', { name: /copy output to clipboard/i }));
+
+    expect(writeText).toHaveBeenCalledWith(withOutput.cmd);
+    await waitFor(() => expect(screen.getByText('Copied')).toBeInTheDocument());
+  });
+
+  test('expands entries independently', () => {
+    const second: ActivityLogEntry = { ...withOutput, id: 'log-3', cmd: 'second entry output' };
+    render(<ActivityView logs={[withOutput, second]} onClearLogs={vi.fn()} />);
+
+    const toggles = screen.getAllByRole('button', { name: /show output/i });
+    fireEvent.click(toggles[0]);
+
+    expect(screen.getByText(/file changed while we backed it up/)).toBeInTheDocument();
+    expect(screen.queryByText('second entry output')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/ActivityView.tsx
+++ b/src/views/ActivityView.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Activity, Clock, Terminal, Trash2 } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { Activity, Check, ChevronRight, Clock, Copy, Terminal, Trash2 } from 'lucide-react';
 import { ActivityLogEntry } from '../types';
 import Button from '../components/Button';
 import { formatDate } from '../utils/formatters';
@@ -10,6 +10,36 @@ interface ActivityViewProps {
 }
 
 const ActivityView: React.FC<ActivityViewProps> = ({ logs, onClearLogs }) => {
+    // Output is opt-in per entry: backup runs can produce a lot of text, so we
+    // only render it once the user asks for it.
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+    const [copiedId, setCopiedId] = useState<string | null>(null);
+    const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => () => {
+        if (copyResetRef.current) clearTimeout(copyResetRef.current);
+    }, []);
+
+    const toggleOutput = (id: string) => {
+        setExpandedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
+    const copyOutput = async (log: ActivityLogEntry) => {
+        try {
+            await navigator.clipboard.writeText(log.cmd || '');
+            setCopiedId(log.id);
+            if (copyResetRef.current) clearTimeout(copyResetRef.current);
+            copyResetRef.current = setTimeout(() => setCopiedId(null), 2000);
+        } catch {
+            // ignore (clipboard may be unavailable in some contexts)
+        }
+    };
+
     // Helper to format "time ago" roughly or just use absolute date
     const formatTime = (iso: string) => {
         try {
@@ -82,7 +112,7 @@ const ActivityView: React.FC<ActivityViewProps> = ({ logs, onClearLogs }) => {
                             </div>
                             <div className="divide-y divide-gray-100 dark:divide-slate-700">
                                 {group.items.map((log) => (
-                            <div key={log.id} className="p-6 hover:bg-slate-50 dark:hover:bg-slate-700/30 transition-colors flex gap-4 items-start group">
+                            <div key={log.id} className="p-6 hover:bg-slate-50 dark:hover:bg-slate-700/30 transition-colors flex gap-4 items-start">
                                 <div className={`mt-1 w-2 h-2 rounded-full flex-shrink-0 shadow-sm ${
                                     log.status === 'success' ? 'bg-green-500 shadow-green-500/50' : 
                                     log.status === 'warning' ? 'bg-yellow-500 shadow-yellow-500/50' : 
@@ -99,12 +129,41 @@ const ActivityView: React.FC<ActivityViewProps> = ({ logs, onClearLogs }) => {
                                     <p className="text-sm text-slate-600 dark:text-slate-400 mt-1 truncate">{log.detail}</p>
                                     
                                     {log.cmd && (
-                                        <div className="mt-3 bg-slate-900 rounded p-2 hidden group-hover:block animate-in fade-in slide-in-from-top-1 duration-200 border border-slate-700">
-                                            <div className="flex items-center gap-2 text-xs text-slate-400 mb-1 border-b border-slate-700 pb-1">
-                                                <Terminal className="w-3 h-3" />
-                                                <span>Command Executed</span>
-                                            </div>
-                                            <code className="text-xs font-mono text-green-400 break-all whitespace-pre-wrap">{log.cmd}</code>
+                                        <div className="mt-3">
+                                            <button
+                                                type="button"
+                                                onClick={() => toggleOutput(log.id)}
+                                                aria-expanded={expandedIds.has(log.id)}
+                                                aria-controls={`activity-output-${log.id}`}
+                                                className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
+                                            >
+                                                <ChevronRight className={`w-3.5 h-3.5 transition-transform ${expandedIds.has(log.id) ? 'rotate-90' : ''}`} />
+                                                {expandedIds.has(log.id) ? 'Hide output' : 'Show output'}
+                                            </button>
+
+                                            {expandedIds.has(log.id) && (
+                                                <div
+                                                    id={`activity-output-${log.id}`}
+                                                    className="mt-2 bg-slate-900 rounded p-2 animate-in fade-in slide-in-from-top-1 duration-200 border border-slate-700"
+                                                >
+                                                    <div className="flex items-center justify-between gap-2 text-xs text-slate-400 mb-1 border-b border-slate-700 pb-1">
+                                                        <span className="flex items-center gap-2">
+                                                            <Terminal className="w-3 h-3" />
+                                                            Output
+                                                        </span>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => copyOutput(log)}
+                                                            aria-label="Copy output to clipboard"
+                                                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded hover:bg-slate-700 hover:text-slate-200 transition-colors"
+                                                        >
+                                                            {copiedId === log.id ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+                                                            {copiedId === log.id ? 'Copied' : 'Copy'}
+                                                        </button>
+                                                    </div>
+                                                    <pre className="max-h-72 overflow-auto custom-scrollbar text-xs font-mono text-green-400 break-all whitespace-pre-wrap">{log.cmd}</pre>
+                                                </div>
+                                            )}
                                         </div>
                                     )}
                                 </div>


### PR DESCRIPTION
Closes #250

## Problem

A user asked for a way to look at the log of a backup that finished with warnings. Today that is effectively impossible:

- For scheduled runs the full borg output *is* stored on the activity entry, but it only appears while the mouse hovers the row (`hidden group-hover:block`), is not reachable by keyboard, has no scroll container and is labelled "Command Executed" although it holds the whole output.
- For manually started jobs the output was collected into an array and then never used, so nothing was kept at all.
- Manual backups started from the dashboard produced no activity entry whatsoever — only a toast that disappears.

## Changes

- **Activity log**: "Show output" toggle per entry (`aria-expanded` / `aria-controls`), scrollable `pre`, copy-to-clipboard button, honest "Output" label. Entries expand independently.
- **Manual job runs**: the collected borg output is attached to the resulting activity entry (success, warning, failure and the failed-prune case).
- **Dashboard backups**: `onLog` was wired to a no-op; it now records a warning/error activity entry including the output. `CreateBackupModal`'s `onLog` gained an optional `status` argument so the caller does not have to guess from the message text.
- **Size cap**: output stored on an entry is truncated to 10k characters, keeping the tail where borg puts its summary and last warnings. This bounds `data.json`, which previously took the scheduled output unbounded (up to 100 retained entries).
- **Consistency**: a scheduled run that exits with a warning is now titled "Scheduled Backup Warning" instead of claiming success next to a warning badge.

The warning-vs-failure semantics themselves were already fixed in #229; this builds on that.

## Not in this PR

Real log files on disk with an "Open log" button per archive (the literal wording of the request). That needs decisions about location, retention and making sure nothing sensitive is written to disk, so it is better kept separate. The change here already covers the reported use case.

## Testing

- `npm run typecheck` — clean
- `npx vitest run` — 45 files, 285 passed / 1 skipped
- New: `src/views/ActivityView.test.tsx` (collapsed by default, toggle on/off, no toggle without output, clipboard copy, independent expansion) and truncation cases in `src/utils/formatters.test.ts`
- `npm run test:e2e:smoke` could **not** be run in my environment: Playwright fails to launch Electron here for every spec, including ones this PR does not touch (`Process failed to launch!`). Left to CI.